### PR TITLE
Removes Enclave + Casper

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -13,7 +13,6 @@
 		#include "map_files\Pahrump-Sunset\RockSprings-Upper.dmm"
 		#include "map_files\Pahrump-Sunset\Warren.dmm"
 		#include "map_files\Pahrump-Sunset\Warren-Upper.dmm"
-		#include "map_files\Pahrump-Sunset\Mountain-Range.dmm"
 		#ifdef TRAVISBUILDING
 			#include "templates.dm"
 		#endif

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -59,6 +59,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"aaO" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "aba" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -78,6 +82,10 @@
 	dir = 4
 	},
 /area/f13/vault)
+"abn" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "abp" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -86,6 +94,10 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"abu" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "abR" = (
 /obj/item/grown/nettle/basic{
 	name = "Kuzudu"
@@ -110,6 +122,12 @@
 /mob/living/simple_animal/hostile/renegade/guardian/shotgunner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"aes" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "aey" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high,
@@ -128,12 +146,30 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/caves)
+"aeJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "afe" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"afh" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "afi" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/broken{
@@ -163,11 +199,40 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
+"agb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/button/door{
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4;
+	id = "sgtofficen"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"agd" = (
+/obj/structure/closet/crate/freezer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"agk" = (
+/obj/structure/sign/poster/sunset/corporate/eyes,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "ago" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"agr" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Engineering"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "agC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -176,6 +241,11 @@
 	desc = "This is a plaque detailing and honouring the corporate dollars lost creating the compound. All craftsmanship is of the highest quality. The Business men are laughing. The Workers are crying. It menaces with spikes of gold."
 	},
 /area/f13/vault)
+"agF" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "agG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -185,6 +255,17 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"agK" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "agO" = (
 /obj/machinery/light{
 	dir = 4;
@@ -230,6 +311,16 @@
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"akd" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "akg" = (
 /obj/structure/sign/warning/radiation{
 	pixel_y = 30
@@ -254,6 +345,20 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/bunker)
+"akG" = (
+/obj/machinery/microwave/stove,
+/obj/structure/sign/poster/contraband/space_cola{
+	pixel_x = 32
+	},
+/obj/item/reagent_containers/food/snacks/grilledcheese,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/mess)
+"akL" = (
+/obj/structure/disposalpipe/broken{
+	dir = 8
+	},
+/turf/open/water,
+/area/f13/caves)
 "alf" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/barber{
@@ -265,6 +370,11 @@
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"alq" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "alw" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
@@ -319,6 +429,21 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"anQ" = (
+/obj/structure/sink/kitchen{
+	desc = "Strictly for filling up mop buckets.";
+	name = "Mop Sink";
+	pixel_y = 25
+	},
+/obj/machinery/light/floor{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
+"apv" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/enclave/hallways)
 "apM" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 1;
@@ -327,6 +452,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"apR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "aqj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -371,6 +507,11 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"asb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "ast" = (
 /obj/effect/overlay/junk/shower{
 	dir = 4
@@ -382,12 +523,35 @@
 "asG" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/vault)
+"asR" = (
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
+"atc" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "ati" = (
 /obj/structure/chair/left{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ats" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "atQ" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -408,6 +572,14 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ava" = (
+/obj/machinery/button/crematorium{
+	id = "enc_crem";
+	pixel_x = 6;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "avk" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/barber{
@@ -425,6 +597,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"awa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/enclave/command)
+"awM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "awT" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13{
@@ -462,6 +643,17 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"ayC" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "azc" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -489,6 +681,18 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"azN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/virology)
+"aAd" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bathroom";
+	req_one_access_txt = "134";
+	id_tag = "enct3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "aAh" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -574,12 +778,38 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"aFi" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/item/grenade/clusterbuster/cleaner,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "aFq" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"aFG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "aGj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
@@ -594,6 +824,28 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/bunker)
+"aHi" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"aHv" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "aHJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -678,6 +930,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"aNQ" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "aOl" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/f13{
@@ -715,6 +974,32 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"aPa" = (
+/obj/structure/bed{
+	layer = 5
+	},
+/obj/structure/bed{
+	pixel_y = 12
+	},
+/obj/item/bedsheet/enclave{
+	layer = 5
+	},
+/obj/item/bedsheet/enclave{
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"aPg" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
 "aPq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -741,6 +1026,13 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"aRn" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "aRy" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light,
@@ -749,6 +1041,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"aSm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "aSq" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 4
@@ -756,6 +1056,16 @@
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"aSv" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/water,
+/area/f13/enclave/rnd)
 "aSw" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/beans,
@@ -804,6 +1114,25 @@
 /obj/item/reagent_containers/food/snacks/f13/steak,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"aVB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
+"aVK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "aVQ" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper,
@@ -825,6 +1154,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/f13/bunker)
+"aWo" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bathroom";
+	req_one_access_txt = "134";
+	id_tag = "enct4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
 "aWX" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -837,12 +1174,30 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"aXp" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
+"aXw" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/f13/enclave)
 "aXN" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg3"
 	},
 /area/f13/bunker)
+"aXZ" = (
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/prison)
 "aYe" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/remains/human,
@@ -869,6 +1224,14 @@
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"baR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	name = "Reactor"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "baT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
@@ -878,6 +1241,11 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"bbC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "bbQ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -1000,6 +1368,19 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"bjb" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/documents/syndicate/blue{
+	desc = "A large pile of papers. On closer inspection, most seem to be armoury inventories and requisitions.";
+	name = "Enclave Armory Reports"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "bje" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -1049,12 +1430,26 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"blY" = (
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/plasteel/five,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "bmp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"bms" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
 "bnt" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -1206,6 +1601,18 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"btV" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/terminal{
+	termtag = "Private"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "buF" = (
 /obj/machinery/door/airlock/maintenance_hatch/abandoned,
 /turf/open/floor/plasteel/f13{
@@ -1251,11 +1658,32 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"bze" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "bzg" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
 /area/f13/ahs)
+"bzy" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/enclave/rnd)
 "bzR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1264,6 +1692,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"bzU" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "bAO" = (
 /obj/structure/sign/poster/official/report_crimes,
 /turf/closed/wall/r_wall/f13vault{
@@ -1297,12 +1729,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"bBR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/effect/turf_decal/stripes/white/end,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "bBZ" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"bCg" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "bCh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
@@ -1316,10 +1761,21 @@
 	icon_state = "dirt"
 	},
 /area/f13/city)
+"bCR" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
+"bDO" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "bEj" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"bEv" = (
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "bFq" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/reinforced,
@@ -1359,6 +1815,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"bGs" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "bGx" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -1376,6 +1839,21 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"bGH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/item/broom,
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/enclave)
 "bGK" = (
 /turf/open/floor/f13{
 	dir = 8;
@@ -1392,15 +1870,54 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"bHg" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Hydroponics";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
+"bHD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "bIB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"bIN" = (
+/obj/machinery/door/poddoor/gate/bunker{
+	id = "pneumatic_door2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
+"bIZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/stack/ore/blackpowder/twenty,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 50
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "bJq" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bJJ" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "bJL" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_bigboss,
@@ -1427,6 +1944,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"bLF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
+"bLI" = (
+/obj/structure/obstacle/barbedwire/end,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bMb" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -1440,6 +1966,10 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"bMp" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "bMw" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -1498,6 +2028,19 @@
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"bPn" = (
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "bPq" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/plasteel/f13{
@@ -1511,6 +2054,10 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bunker)
+"bQf" = (
+/obj/item/fishy/lobster,
+/turf/open/water,
+/area/f13/enclave/prison)
 "bQl" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/cleanable/greenglow/radioactive,
@@ -1600,6 +2147,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
+"bTV" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1;
+	name = "Storage";
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "bUo" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/structure/reagent_dispensers/barrel/old,
@@ -1615,6 +2173,11 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"bUS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/pandemic,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "bUX" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -1623,6 +2186,12 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"bVi" = (
+/obj/machinery/firealarm{
+	name = "INTRUDER ALERT"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "bVj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1631,6 +2200,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"bVs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "bVH" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -1652,6 +2228,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"bYa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "bYb" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -1778,6 +2359,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"ceq" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "cex" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/tunnel,
@@ -1803,6 +2390,27 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"cfA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
+"cfP" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Sergeant's Quarters";
+	req_one_access_txt = "134";
+	id_tag = "sgtofficen"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "cfW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1819,6 +2427,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"cgg" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "cgE" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1832,6 +2450,13 @@
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"chu" = (
+/obj/structure/sign/departments/security,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "chx" = (
 /obj/machinery/light{
 	dir = 1
@@ -1856,6 +2481,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ciV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "cja" = (
 /obj/structure/sign/poster/contraband/smoke,
 /turf/closed/wall/mineral/wood,
@@ -1869,6 +2498,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"cjB" = (
+/obj/structure/sign/departments/science,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "cjG" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
@@ -1936,6 +2569,12 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/vault)
+"coU" = (
+/obj/structure/loot_pile,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/enclave)
 "cpc" = (
 /obj/structure/barricade/concrete,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
@@ -1970,12 +2609,26 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"cqM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/hallways)
 "crf" = (
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
 	},
 /area/f13/legion)
+"crB" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "crO" = (
 /obj/structure/statue/sandstone/gravestone,
 /turf/open/indestructible/ground/outside/desert,
@@ -1996,6 +2649,9 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"csH" = (
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "csZ" = (
 /obj/structure/bed/mattress,
 /obj/machinery/light{
@@ -2034,6 +2690,22 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/caves)
+"cvd" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"cvF" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/closet/locker,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
+"cvS" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "cvV" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/light/small{
@@ -2057,6 +2729,20 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"cwx" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"cxd" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "cxg" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -2068,12 +2754,38 @@
 	name = "metal plating"
 	},
 /area/f13/bunker)
+"cxr" = (
+/obj/structure/rack,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "cxK" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"cyl" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "cyr" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -2093,6 +2805,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"cyG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "cyQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/engineering,
@@ -2107,6 +2825,13 @@
 "czW" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"czZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "cAh" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -2151,10 +2876,38 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"cAS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"cBv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"cCa" = (
+/obj/machinery/door/airlock/hatch{
+	name = "No Mans Land";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/enclave)
 "cCt" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault)
+"cCC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "cCK" = (
 /obj/structure/closet/secure_closet/goodies{
 	anchorable = 0;
@@ -2193,15 +2946,47 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault)
+"cFd" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
+"cFv" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "cFz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cFH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/fire,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "reinforced wall";
+	icon = 'icons/turf/walls/reinforced_wall.dmi'
+	},
+/area/f13/enclave)
 "cFT" = (
 /mob/living/simple_animal/hostile/renegade/grunt/gunner,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"cFW" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "cGA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/radroach,
@@ -2221,6 +3006,12 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"cHA" = (
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "cHR" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13{
@@ -2289,6 +3080,11 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"cLh" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/floor/grass,
+/area/f13/enclave/hydroponics)
 "cLi" = (
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -2318,6 +3114,29 @@
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"cLS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
+/area/f13/enclave/hallways)
+"cLW" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "cMu" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2333,6 +3152,13 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"cNo" = (
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "cNE" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -2361,6 +3187,20 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"cOm" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/item/clothing/head/f13/army/beret/specialforces,
+/obj/effect/decal/remains{
+	desc = "He is in your walls";
+	icon_state = "remains";
+	name = "Him"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "cOs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -2429,6 +3269,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"cRq" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "cRr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2500,6 +3348,21 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"cVU" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "cWE" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/human/body,
@@ -2580,12 +3443,32 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"cZV" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "dae" = (
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"dah" = (
+/obj/machinery/camera/autoname{
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"daq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "daz" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -2606,6 +3489,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"dbr" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "dbP" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/barber{
@@ -2613,6 +3502,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"dbZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "dcJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/energybar,
@@ -2628,6 +3522,29 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"dcT" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
+"dcX" = (
+/obj/structure/showcase/horrific_experiment,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
+"ddy" = (
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "ddz" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -2663,6 +3580,12 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"dey" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "deM" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2697,6 +3620,12 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"dfY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "dgg" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2740,9 +3669,21 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"dhq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "dhw" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/ncr)
+"dhx" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/obj/effect/turf_decal/stripes/white/corner,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
 "dhF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2767,6 +3708,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"dip" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "diI" = (
 /obj/effect/decal/remains/human,
 /obj/structure/closet,
@@ -2838,6 +3787,20 @@
 	dir = 6
 	},
 /area/f13/vault)
+"dkV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "encroom1";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "dlc" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -2866,6 +3829,14 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"dny" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "doa" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -2890,9 +3861,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"dov" = (
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "doB" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
+"dpp" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "dpr" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2921,6 +3902,10 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"dpV" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "dqi" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -2951,6 +3936,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"dsI" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "dsJ" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -2972,6 +3961,18 @@
 /obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"dtw" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/old{
+	id = "enc_brig_shutters";
+	name = "security shutter"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "dty" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
@@ -3017,6 +4018,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault)
+"dvv" = (
+/turf/open/water,
+/area/f13/caves)
 "dvR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -3037,6 +4041,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"dwZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed,
+/obj/item/bedsheet/enclave,
+/turf/open/floor/carpet/black,
+/area/f13/enclave/command)
 "dxd" = (
 /obj/machinery/light{
 	dir = 4
@@ -3068,6 +4078,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"dyH" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
 "dzg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3078,6 +4095,18 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
+"dAW" = (
+/obj/structure/sign/warning/fire,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"dBs" = (
+/obj/machinery/aug_manipulator,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "dCw" = (
 /obj/machinery/shower{
 	dir = 8
@@ -3087,6 +4116,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"dCJ" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
+"dCZ" = (
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "dDl" = (
 /turf/closed/wall/f13/vault,
 /area/f13/wasteland)
@@ -3100,6 +4139,16 @@
 "dDC" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"dDT" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "dEa" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/vault)
@@ -3184,6 +4233,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/f13/bunker)
+"dGx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/mess)
 "dGC" = (
 /obj/structure/table/reinforced,
 /obj/item/circular_saw,
@@ -3212,6 +4273,24 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"dHj" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Medical Bay";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"dHF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"dHH" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "dHM" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
@@ -3316,6 +4395,9 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"dMA" = (
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "dMF" = (
 /obj/machinery/light{
 	dir = 1;
@@ -3366,6 +4448,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"dQe" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "dQf" = (
 /obj/structure/closet/crate/footchest,
 /obj/item/t_scanner/adv_mining_scanner,
@@ -3392,12 +4481,45 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dRa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
+"dRd" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "bos_ps1";
+	name = "privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
+"dRl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "dRx" = (
 /obj/structure/sign/poster/prewar/protectron,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"dSe" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/gun/ballistic/shotgun/police,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
 "dSf" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3424,6 +4546,13 @@
 	dir = 1
 	},
 /area/f13/bunker)
+"dTu" = (
+/obj/structure/obstacle/barbedwire/end{
+	dir = 1;
+	pixel_x = 7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "dUc" = (
 /obj/machinery/door/airlock/public/glass{
 	req_access_txt = "31"
@@ -3468,6 +4597,11 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"dVX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "dWx" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -3510,6 +4644,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"dYn" = (
+/obj/structure/sign/poster/prewar/poster61,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "dYz" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -3520,6 +4658,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"dZf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 34
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "dZx" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
@@ -3576,6 +4723,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"ecF" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "edb" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table,
@@ -3583,6 +4739,14 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"edA" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
 "edD" = (
 /obj/structure/frame,
 /obj/item/stack/cable_coil/red,
@@ -3606,6 +4770,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"edZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "eea" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -3624,6 +4795,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"eej" = (
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = -32
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
+"eeB" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "eeI" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -3644,6 +4828,12 @@
 	icon_state = "plating"
 	},
 /area/f13/radiation)
+"efD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "ege" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -3740,6 +4930,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"ejw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "ejy" = (
 /obj/machinery/power/am_control_unit,
 /obj/structure/cable{
@@ -3750,6 +4950,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"ejV" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"ekx" = (
+/obj/effect/turf_decal/loading_area,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/wasteland)
 "ekT" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
@@ -3776,6 +4988,11 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"elz" = (
+/obj/structure/curtain,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "elF" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -3804,6 +5021,10 @@
 "emn" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"emu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "emX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
@@ -3833,6 +5054,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"epe" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "epH" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	name = "Conscripted Engineer"
@@ -3889,6 +5116,10 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"ero" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "err" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi';
@@ -3917,6 +5148,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"esm" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
 "esT" = (
 /obj/machinery/light{
 	dir = 4
@@ -3938,6 +5173,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"etU" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/drain,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
+"etV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "eus" = (
 /obj/structure/bedsheetbin/empty,
 /obj/structure/table,
@@ -3955,6 +5203,17 @@
 /mob/living/simple_animal/hostile/renegade/smasher,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ewj" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Mining Area";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
+"ews" = (
+/obj/machinery/rnd/server/enclave,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "exi" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/barber{
@@ -3988,6 +5247,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"eyu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "eza" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grown/apple/gold{
@@ -4121,6 +5388,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"eEK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "eER" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -4144,6 +5418,12 @@
 /obj/item/reagent_containers/food/snacks/burger/bigbite,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"eHh" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "eHl" = (
 /obj/structure/safe,
 /obj/item/stack/spacecash/c1000,
@@ -4151,6 +5431,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"eHB" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "eHD" = (
 /obj/structure/railing{
 	dir = 4
@@ -4162,6 +5446,15 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"eIs" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Robotics"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "eIF" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/item/pda/quartermaster,
@@ -4181,6 +5474,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"eJi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "eJj" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -4193,12 +5494,21 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"eJl" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "eJN" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"eJZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/dresser,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "eKE" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution{
@@ -4219,6 +5529,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"eLZ" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "eMF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/waffles,
@@ -4334,6 +5648,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"eSP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"eSW" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/enclave)
 "eTA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -4351,6 +5676,17 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"eUM" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "eUO" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
@@ -4383,6 +5719,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"eWl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "eWx" = (
 /obj/structure/fence{
 	dir = 4
@@ -4405,12 +5746,42 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"eWX" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "eXe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"eXB" = (
+/obj/structure/decoration/vent/rusty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
+"eXY" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/decoration/vent,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "eYf" = (
 /obj/machinery/light{
 	dir = 8
@@ -4446,11 +5817,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"eZQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hydroponics)
 "eZS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"fav" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "fbg" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -4461,6 +5847,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"fbB" = (
+/obj/item/am_shielding_container,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/enclave/reactor)
 "fbT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/blood/radaway,
@@ -4469,6 +5862,10 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"fbU" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "fcd" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/desert,
@@ -4516,6 +5913,40 @@
 /obj/effect/spawner/bundle/f13/m1911,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"fdQ" = (
+/obj/structure/table,
+/obj/machinery/computer/security/enclave,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"feu" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/mre/menu3,
+/obj/item/storage/box/mre/menu4/safe,
+/obj/item/storage/box/mre/menu4/safe,
+/obj/item/storage/box/mre/menu2/safe,
+/obj/item/storage/box/mre/menu2/safe,
+/obj/item/storage/box/mre/menu1/safe,
+/obj/item/storage/box/mre/menu1/safe,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
 "feA" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -4591,6 +6022,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"fjG" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "fjH" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -4636,6 +6076,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"flU" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "fmf" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel{
@@ -4693,10 +6140,21 @@
 /obj/effect/landmark/start/f13/vaultengineer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"fpM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "fpS" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/radiation)
+"fpV" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "fqR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/metal/fifty,
@@ -4711,6 +6169,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
+"frf" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "frp" = (
 /obj/structure/chair/comfy/lime{
 	dir = 1
@@ -4732,6 +6196,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"frV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "fsx" = (
 /obj/machinery/door/airlock/security{
 	name = "Gatehouse";
@@ -4759,10 +6227,32 @@
 /obj/structure/closet/crate/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"ftm" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
 "ftT" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"ftU" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave/armory)
 "fup" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = 30
@@ -4776,6 +6266,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/f13/bunker)
+"fva" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "fvu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4807,6 +6301,19 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
+"fxH" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/obj/machinery/base_dispenser/enclave,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "fxK" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/security.dmi';
@@ -4841,6 +6348,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"fyJ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/spacecash/c1000{
+	desc = "One thousand United States Dollars, probably not so useful after the Great War but kept as a reminder of what was lost.";
+	name = "one thousand dollars";
+	singular_name = "ten hundred dollar bill"
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/pda/captain,
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "fyZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4866,6 +6387,12 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fBc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/bundle/weapon/piperifle,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "fCa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4883,6 +6410,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"fDc" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "fDJ" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -4924,6 +6457,13 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"fEQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "fFa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5022,6 +6562,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"fIn" = (
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "fIx" = (
 /obj/structure/sign/poster/official/help_others,
 /turf/closed/wall/r_wall/f13vault{
@@ -5032,6 +6575,12 @@
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"fJr" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "fJN" = (
 /obj/structure/mirror,
 /turf/closed/indestructible/f13vaultrusted,
@@ -5050,6 +6599,19 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"fLn" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/enclave/rnd)
 "fMf" = (
 /obj/structure/window/spawner/east,
 /obj/structure/window/spawner/north,
@@ -5079,12 +6641,60 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
+"fMj" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/drain,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
+"fMt" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "fMA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"fMW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
+"fNc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
+"fNg" = (
+/obj/item/cautery,
+/obj/item/scalpel,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "fNp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5107,6 +6717,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"fNW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "fOu" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -5127,6 +6741,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"fPu" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/f13/enclave)
 "fPw" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/bunker)
@@ -5162,6 +6786,10 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"fSO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "fTk" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -5169,6 +6797,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"fTu" = (
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "fTy" = (
 /obj/structure/bodycontainer/crematorium{
 	id = 700
@@ -5204,6 +6839,15 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"fUG" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Lieutenant's Office";
+	req_one_access_txt = "134";
+	id_tag = "ltoffice"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave)
 "fVb" = (
 /obj/structure/rack,
 /obj/item/grenade/syndieminibomb/concussion/frag,
@@ -5229,10 +6873,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"fVz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "fVP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/vault)
+"fWl" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "fWM" = (
 /obj/structure/table,
 /obj/item/stamp/hos,
@@ -5256,6 +6909,10 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"fXg" = (
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "fXq" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/f13{
@@ -5317,6 +6974,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"fYm" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "fYw" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
@@ -5363,6 +7030,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"fZU" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "gae" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
@@ -5375,6 +7045,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"gaP" = (
+/obj/structure/curtain,
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "gbg" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/barber{
@@ -5395,6 +7073,23 @@
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"gbn" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/obj/machinery/button/door{
+	id = "enct3";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "gbs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5427,6 +7122,11 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"gdH" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "geJ" = (
 /obj/item/kirbyplants/random,
 /obj/structure/railing{
@@ -5468,6 +7168,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"gfn" = (
+/obj/structure/table,
+/obj/item/storage/firstaid,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "gfp" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -5482,6 +7187,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"gfM" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bathroom";
+	req_one_access_txt = "134";
+	id_tag = "enct2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "ghe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
@@ -5517,6 +7230,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
+"ghV" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/enclave)
 "gin" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13{
@@ -5536,6 +7258,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"gjC" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "gjT" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -5574,6 +7302,18 @@
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"gky" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
+"glj" = (
+/obj/structure/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "glJ" = (
 /obj/machinery/light{
 	dir = 1;
@@ -5586,6 +7326,25 @@
 /obj/item/clothing/suit/chaplain/holidaypriest,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gmL" = (
+/obj/structure/table/optable,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"goA" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "goX" = (
 /obj/structure/nest/protectron{
 	max_mobs = 1
@@ -5594,6 +7353,12 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"gpB" = (
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "gpW" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -5631,6 +7396,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"grZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "gsh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -5641,6 +7414,20 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"gsJ" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "gtE" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -5654,6 +7441,9 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"gtS" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "guV" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -5677,6 +7467,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"gvG" = (
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"gvZ" = (
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "gwD" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -5687,6 +7487,25 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gxj" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
+"gxm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "gyj" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/effect/decal/remains/human,
@@ -5763,6 +7582,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"gDa" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "gDe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5772,6 +7595,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"gDg" = (
+/obj/structure/decoration/vent/rusty,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "gDk" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13,
@@ -5819,6 +7654,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"gFM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "gGg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5843,6 +7682,10 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gHa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "gHb" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5934,6 +7777,9 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"gKP" = (
+/turf/closed/wall/r_wall,
+/area/f13/enclave/medbay)
 "gLc" = (
 /obj/structure/closet,
 /turf/open/floor/mineral/plastitanium,
@@ -5970,6 +7816,20 @@
 /mob/living/simple_animal/hostile/renegade/smasher,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gLW" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "gMj" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -5980,6 +7840,9 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/bunker)
+"gNa" = (
+/turf/open/floor/plasteel/stairs,
+/area/f13/enclave/hallways)
 "gNI" = (
 /obj/item/crafting/reloader,
 /obj/structure/table,
@@ -6008,6 +7871,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13,
 /area/f13/city)
+"gPH" = (
+/obj/machinery/computer/pandemic,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "gPL" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -6018,6 +7885,9 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"gPS" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "gQQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -6030,6 +7900,16 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"gRL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/sunset/nukagirl,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"gRQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/loot_pile,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "gRS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -6071,6 +7951,14 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"gTD" = (
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/toy/figure/virologist,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "gUq" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/radiation,
@@ -6079,6 +7967,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/f13/bunker)
+"gUD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "gVd" = (
 /obj/structure/rack/shelf_metal,
 /obj/machinery/light{
@@ -6116,6 +8013,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"gWD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
+"gXi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "gXz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -6153,6 +8067,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"gYJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "gYY" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -6186,6 +8109,17 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"haD" = (
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/briefing)
 "haH" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/barber{
@@ -6259,6 +8193,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"hdM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "hdQ" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/f13{
@@ -6299,6 +8238,20 @@
 /obj/item/clothing/head/helmet/f13/power_armor/excavator,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"hfx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/obj/structure/grille/broken,
+/obj/item/seeds/grass{
+	desc = "You should probably grow this and touch some grass for once."
+	},
+/obj/structure/wreck/trash/secway,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "hgk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -6306,6 +8259,14 @@
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"hgE" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "hhx" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -6322,6 +8283,11 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hhS" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hiB" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -6339,6 +8305,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"hiP" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"hiR" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "hji" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/effect/decal/cleanable/dirt,
@@ -6355,6 +8330,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"hjC" = (
+/obj/structure/sign/departments/engineering,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "hjF" = (
 /obj/structure/table,
 /obj/item/ship_in_a_bottle,
@@ -6375,6 +8354,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"hjY" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/wasteland)
+"hkl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "hkO" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -6393,6 +8383,28 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"hlq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/enclave,
+/obj/machinery/button/door{
+	id = "ltoffice";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
+"hls" = (
+/obj/structure/closet/locker,
+/obj/item/storage/box/gloves,
+/obj/item/roller,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"hlR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "hlY" = (
 /mob/living/simple_animal/hostile/renegade/engie/breacher,
 /turf/open/floor/f13{
@@ -6412,6 +8424,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"hns" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "hnG" = (
 /obj/structure/debris/v1,
 /turf/closed/mineral/random/low_chance,
@@ -6422,6 +8445,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hnY" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "hoe" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating/tunnel,
@@ -6436,6 +8470,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"hpm" = (
+/obj/machinery/vending/snack,
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
 "hpo" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/f13{
@@ -6449,6 +8488,12 @@
 /obj/item/multitool/uplink,
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"hpE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "hpH" = (
 /obj/structure/table/reinforced,
 /obj/item/ammo_box/shotgun/buck,
@@ -6476,6 +8521,12 @@
 	dir = 1
 	},
 /area/f13/bunker)
+"hqu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "hqv" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -6634,6 +8685,26 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/bunker)
+"hxf" = (
+/obj/machinery/light/small{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/obj/structure/closet/locker,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
+"hxr" = (
+/obj/structure/sign/departments/security,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"hxJ" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	name = "Gym"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
 "hyk" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/timeddoor/sixtyminute,
@@ -6653,11 +8724,35 @@
 /obj/item/flag/renegade,
 /turf/closed/wall/mineral/wood,
 /area/f13/city)
+"hzx" = (
+/obj/structure/rack,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"hAe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/flag/enclave,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "hAm" = (
 /obj/machinery/hydroponics/soil/crafted,
 /mob/living/simple_animal/hostile/renegade/drifter/sniper,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hAs" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+	},
+/turf/closed/indestructible/f13vaultrusted{
+	name = "reinforced wall";
+	icon = 'icons/turf/walls/reinforced_wall.dmi'
+	},
+/area/f13/enclave)
 "hAx" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/barber{
@@ -6751,6 +8846,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"hFc" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "hFd" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -6762,6 +8866,14 @@
 	name = "metal plating"
 	},
 /area/f13/bunker)
+"hFy" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bathroom";
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "hFU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -6859,6 +8971,17 @@
 /obj/machinery/door/unpowered/securedoor/legion,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"hMP" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/enclave/rnd)
+"hNF" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "hNR" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/barber{
@@ -6885,6 +9008,22 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"hOa" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
+"hOe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "hOj" = (
 /obj/machinery/light{
 	dir = 1
@@ -6951,6 +9090,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"hRC" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Armory";
+	req_one_access_txt = "134"
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "hRQ" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -6958,6 +9105,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hRY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "hSa" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -7062,6 +9216,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"hXl" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "hXG" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -7083,6 +9241,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"hYr" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "hZr" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -7137,6 +9301,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"ibB" = (
+/obj/machinery/vending/nukacolavendfull,
+/obj/effect/turf_decal/stripes/white/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
 "ibQ" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight{
@@ -7150,6 +9319,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"ibV" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "icD" = (
 /obj/structure/table,
 /obj/item/storage/box/pillbottles,
@@ -7181,6 +9360,13 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/ahs)
+"icG" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "iej" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/timeddoor/sixtyminute,
@@ -7202,6 +9388,17 @@
 	icon_state = "whitepurplerustychess2"
 	},
 /area/f13/ahs)
+"ifv" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -13
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "ifA" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -7224,6 +9421,15 @@
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"igm" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/mechfab,
+/obj/item/stack/cable_coil/random/five,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "igE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7240,10 +9446,18 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ihx" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "iiG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"ija" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "ijp" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Science"
@@ -7253,6 +9467,38 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"ijs" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/hallways)
+"iju" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
+"ijy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
+"ijL" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "enct4";
+	normaldoorcontrol = 1;
+	pixel_x = -28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "ijS" = (
 /obj/structure/chair/right,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -7307,6 +9553,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"imW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/obj/machinery/button/door{
+	id = "enct1";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "imZ" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7350,6 +9613,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"iph" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "ipz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -7370,6 +9642,9 @@
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iqB" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "iqI" = (
 /obj/structure/debris/v3{
 	pixel_x = -11;
@@ -7403,6 +9678,9 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"irz" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "irG" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -7447,6 +9725,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/ncr)
+"isV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Private"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "itj" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -7481,6 +9767,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"ium" = (
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
+	},
+/obj/machinery/camera/autoname{
+	network = list("Enclave")
+	},
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "iup" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7525,6 +9820,21 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"ivw" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/structure/sign/poster/contraband/pinup_pink{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
+"iwd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "iwu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -7605,6 +9915,12 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iAC" = (
+/obj/machinery/camera/autoname{
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/prison)
 "iBl" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -7640,6 +9956,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"iDv" = (
+/obj/structure/curtain{
+	color = "red"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave)
 "iDB" = (
 /mob/living/simple_animal/hostile/renegade/defender/assaulter,
 /turf/open/floor/f13{
@@ -7725,6 +10051,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"iGa" = (
+/obj/machinery/light/small{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "iGi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -7735,6 +10069,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"iGk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
+"iHg" = (
+/obj/structure/loot_pile,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/enclave)
 "iHn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7775,12 +10122,54 @@
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iJq" = (
+/obj/item/stock_parts/manipulator/nano,
+/obj/item/stock_parts/manipulator/nano,
+/obj/item/stock_parts/manipulator/nano,
+/obj/item/stock_parts/manipulator/nano,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/capacitor/adv,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/bloodbankgen,
+/obj/item/circuitboard/machine/chem_heater,
+/obj/item/circuitboard/machine/cell_charger,
+/obj/item/circuitboard/computer/prisoner,
+/obj/item/circuitboard/machine/reagentgrinder,
+/obj/item/circuitboard/machine/sleeper,
+/obj/item/circuitboard/machine/sleeper,
+/obj/item/circuitboard/computer/operating,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
+"iJB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "iJC" = (
 /obj/structure/foamedmetal,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"iJI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "iKa" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_bigboss,
@@ -7831,11 +10220,41 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"iLR" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
+"iLY" = (
+/obj/structure/fans/tiny,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "iMq" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"iMt" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
+"iMX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "iNa" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -7909,6 +10328,12 @@
 /obj/structure/guncase,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"iQz" = (
+/mob/living/simple_animal/crab/evil/kreb{
+	name = "Encrab"
+	},
+/turf/open/water,
+/area/f13/enclave/prison)
 "iQM" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -7947,6 +10372,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"iRq" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "iSc" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
@@ -7970,6 +10399,18 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/underground/cave)
+"iSL" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "iTP" = (
 /obj/structure/chair{
 	dir = 8
@@ -7991,6 +10432,26 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"iUj" = (
+/obj/effect/turf_decal/loading_area,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
+"iUk" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/effect/light_emitter,
+/obj/item/clothing/head/cowboyhat/pink,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "iUB" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/plasteel/barber{
@@ -8015,6 +10476,27 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/brotherhood)
+"iVu" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/razor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
+"iVw" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"iVD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "iVU" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/toy/plush/lizardplushie,
@@ -8038,6 +10520,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"iYo" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/item/soap/deluxe,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "iYv" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8048,6 +10540,18 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"iZs" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "jaa" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -8071,6 +10575,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"jaE" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "jaI" = (
 /obj/machinery/chem_master,
 /obj/machinery/light{
@@ -8151,6 +10659,24 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/f13/vault)
+"jdc" = (
+/obj/item/reagent_containers/food/snacks/store/bread/plain{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/snacks/store/cheesewheel{
+	pixel_x = 6
+	},
+/obj/item/storage/bag/easterbasket{
+	name = "Picnic Basket"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/grass,
+/area/f13/enclave/hydroponics)
 "jdd" = (
 /turf/closed/wall/f13/vault,
 /area/f13/city)
@@ -8182,9 +10708,17 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"jex" = (
+/obj/structure/debris/v3,
+/turf/closed/mineral/random/low_chance,
+/area/f13/underground/cave)
 "jfd" = (
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"jfe" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "jfj" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
 /obj/structure/closet,
@@ -8193,12 +10727,26 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"jfL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "jfQ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"jgc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "jgp" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -8221,6 +10769,10 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/f13/tunnel,
 /area/f13/vault)
+"jhz" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "jhJ" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -8247,6 +10799,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"jju" = (
+/obj/item/flag/enclave,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/box/donkpockets,
@@ -8262,6 +10818,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"jkc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/punching_bag,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "jkj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8277,6 +10843,30 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"jkn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/hatch{
+	name = "Robotics"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
+"jkt" = (
+/mob/living/simple_animal/chicken{
+	name = "\improper Bitch"
+	},
+/turf/open/floor/grass,
+/area/f13/enclave/hydroponics)
+"jkS" = (
+/obj/structure/decoration/vent,
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "jlg" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -8339,6 +10929,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"jpW" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "jqa" = (
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall/r_wall/f13vault{
@@ -8375,6 +10969,18 @@
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jsk" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
+"jsI" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
 "jtg" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -8412,6 +11018,22 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"jtR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed{
+	pixel_y = 7
+	},
+/obj/machinery/iv_drip{
+	pixel_x = 13;
+	pixel_y = 2
+	},
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "jtS" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -8440,6 +11062,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"jva" = (
+/obj/machinery/computer/rdconsole/core/enclave{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "jvY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
@@ -8453,6 +11081,11 @@
 /obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"jwz" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "jwJ" = (
 /obj/effect/decal/hammerandsickle,
 /obj/structure/cable{
@@ -8468,17 +11101,56 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/ahs)
+"jwU" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/flag/enclave,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "jwW" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"jxo" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "jxR" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13,
 /area/f13/city)
+"jxV" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"jyb" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "jyn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8534,6 +11206,14 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"jzN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Private";
+	dir = 0
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "jBr" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/grenade/smokebomb,
@@ -8573,10 +11253,21 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"jCa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/computer,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "jCj" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plating,
 /area/f13/bunker)
+"jCE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "jCL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line,
@@ -8586,6 +11277,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"jDe" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
+"jDO" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/wasteland)
 "jDP" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/f13{
@@ -8604,6 +11305,14 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"jEl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/wasteland)
 "jEW" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 32
@@ -8612,6 +11321,31 @@
 	dir = 1
 	},
 /area/f13/vault)
+"jFb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"jFT" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
+"jGQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "jGV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8623,6 +11357,18 @@
 "jHa" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"jHp" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/melee/onehanded/slavewhip,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
 "jHr" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -8641,6 +11387,16 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"jHV" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "jIi" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -8710,6 +11466,16 @@
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"jLH" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "jLJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -8723,6 +11489,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"jMt" = (
+/obj/machinery/processor,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/mess)
 "jMu" = (
 /obj/machinery/door/airlock/command{
 	name = "Bot Control";
@@ -8733,10 +11506,27 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"jMA" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"jMJ" = (
+/obj/structure/decoration/vent,
+/obj/item/fishy/lobster,
+/turf/open/water,
+/area/f13/enclave/prison)
 "jMQ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jNC" = (
+/obj/machinery/light/small/broken{
+	light_color = "#F5CDA6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/campfire/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/wasteland)
 "jNS" = (
 /obj/structure/timeddoor,
 /turf/closed/indestructible/f13vaultrusted,
@@ -8836,12 +11626,28 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"jRR" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave/prison)
 "jSK" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault)
+"jTl" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "jTr" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -8855,6 +11661,15 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"jTC" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "jTJ" = (
 /obj/structure/curtain,
 /obj/structure/decoration/vent,
@@ -8869,11 +11684,34 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"jUX" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	id_tag = "encroom1"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
+"jVd" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/f13/enclave/hydroponics)
 "jVk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/floor/f13,
 /area/f13/city)
+"jVE" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
+"jVW" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "jWi" = (
 /obj/structure/table/reinforced,
 /obj/item/paper,
@@ -8892,6 +11730,47 @@
 	dir = 4
 	},
 /area/f13/vault)
+"jYd" = (
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_on";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_ship";
+	name = "old hologram";
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/briefing)
+"jYh" = (
+/obj/effect/landmark/start/f13/encborg,
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
+"jYA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "jYB" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/good,
 /turf/open/floor/plasteel/barber{
@@ -8905,6 +11784,11 @@
 /obj/item/reagent_containers/food/snacks/grown/potato,
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
+"jYS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
 "jYZ" = (
 /obj/effect/decal/cleanable/blood/xtracks{
 	dir = 4
@@ -8921,6 +11805,13 @@
 "jZk" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jZm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/enclave)
 "jZu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8988,6 +11879,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"kcP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "kcU" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -9094,6 +11991,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"kif" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "kiI" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1;
@@ -9169,6 +12072,16 @@
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
+"kmz" = (
+/obj/structure/closet/crate/radiation,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "kmG" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
@@ -9186,10 +12099,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"knH" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/decoration/vent,
+/obj/structure/window/reinforced,
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "knQ" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13,
 /area/f13/wasteland)
+"koo" = (
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/f13/encborg,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "koy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris,
@@ -9260,6 +12186,21 @@
 /obj/item/target/alien,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"kqG" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
+	},
+/obj/effect/landmark/start/f13/uscpl,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
+"kro" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "krp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -9276,6 +12217,15 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"krI" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Support Staff's Quarters";
+	req_one_access_txt = "134";
+	id_tag = "sstaffofficen"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "krM" = (
 /obj/machinery/camera/autoname{
 	dir = 10
@@ -9290,6 +12240,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"ksd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Shutter Camera";
+	network = list("Enclave");
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "ksl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -9298,6 +12259,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"kso" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "ksL" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood,
@@ -9305,6 +12273,15 @@
 	icon_state = "whitepurplerustychess2"
 	},
 /area/f13/ahs)
+"ksV" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/old{
+	id = "enc_brig_shutters";
+	name = "security shutter"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "ktn" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -9318,6 +12295,12 @@
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/bunker)
+"ktF" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "kuk" = (
 /obj/item/paper,
 /obj/item/pen,
@@ -9336,6 +12319,12 @@
 	dir = 4
 	},
 /area/f13/bunker)
+"kux" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/meatballsub,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "kuA" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -9357,6 +12346,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"kwt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "kwv" = (
 /turf/open/floor/carpet/black,
 /area/f13/caves)
@@ -9365,6 +12363,19 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kwF" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
+"kwT" = (
+/obj/structure/curtain,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "kxi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
@@ -9404,6 +12415,26 @@
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"kyI" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"kyP" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
+/area/f13/enclave/hallways)
 "kzg" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -9432,6 +12463,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"kzV" = (
+/obj/structure/table,
+/obj/item/paper/guides/jobs/medical/morgue,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "kAe" = (
 /obj/effect/landmark/start/f13/overseer,
 /obj/structure/cable{
@@ -9449,6 +12485,11 @@
 	name = "metal plating"
 	},
 /area/f13/bunker)
+"kBk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "kCe" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -9456,6 +12497,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"kCf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "reinforced wall";
+	icon = 'icons/turf/walls/reinforced_wall.dmi'
+	},
+/area/f13/enclave)
 "kCh" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/junker/boss/renegade,
@@ -9465,6 +12513,40 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"kCl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"kCq" = (
+/obj/structure/ore_box,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "kCw" = (
 /obj/structure/nest/supermutant/ranged,
 /turf/open/floor/f13,
@@ -9544,6 +12626,18 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"kEF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bathroom";
+	req_one_access_txt = "134";
+	id_tag = "enct1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
+"kEI" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "kEJ" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9569,6 +12663,10 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/city)
+"kFX" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "kGB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -9596,6 +12694,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/mountain_bunker)
+"kHK" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/item/broom,
+/obj/item/storage/belt/fannypack,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/jammer{
+	name = "extended range radio jammer";
+	range = 42
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "kHO" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -9628,6 +12740,18 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"kJo" = (
+/obj/structure/table/reinforced,
+/obj/item/papercutter,
+/obj/structure/decoration/clock/old/active{
+	pixel_y = 32
+	},
+/obj/item/documents/syndicate/blue{
+	desc = "Top Secret Documents detailing sensitive Enclave operational intelligence. These documents are verified with the Enclave Research and Development wax seal.";
+	name = "Enclave Research and Development Reports"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "kJt" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13{
@@ -9649,6 +12773,17 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"kJW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/complianceregulator,
+/obj/item/gun/energy/laser/pistol,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "kJZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -9684,6 +12819,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"kLk" = (
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Enclave Outpost, Armory"
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "kLq" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/debris/v1{
@@ -9755,6 +12899,47 @@
 /obj/structure/table/reinforced,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"kNl" = (
+/obj/structure/bed{
+	pixel_y = 7
+	},
+/obj/machinery/iv_drip{
+	pixel_x = 13;
+	pixel_y = 2
+	},
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"kNS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
+"kOL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/virology)
+"kOW" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/button/door{
+	id = "sstaffofficen";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "kPA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
@@ -9774,6 +12959,12 @@
 /obj/item/stack/sheet/prewar/five,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"kQR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "kRj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
@@ -9788,6 +12979,10 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"kTb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "kTi" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armory";
@@ -9810,6 +13005,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"kUg" = (
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"kUj" = (
+/obj/structure/bed,
+/obj/item/bedsheet/enclave,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "kUn" = (
 /obj/effect/decal/cleanable/blood/old,
 /mob/living/simple_animal/hostile/supermutant,
@@ -9847,6 +13055,17 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"kVO" = (
+/obj/structure/table,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "kVX" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/guides/jobs/engi/solars{
@@ -9856,6 +13075,12 @@
 /obj/item/stamp/qm,
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
+"kWd" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "kWg" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/f13{
@@ -9880,6 +13105,12 @@
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"kWB" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "kWL" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/robot_debris,
@@ -9967,6 +13198,23 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"kZu" = (
+/obj/structure/table/reinforced,
+/obj/item/folder{
+	icon_state = "folder_syndie";
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/folder{
+	icon_state = "folder_syndie";
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/folder{
+	icon_state = "folder_syndie"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "kZz" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
@@ -10007,6 +13255,27 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"laG" = (
+/obj/structure/sign/departments/restroom,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"laH" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/seeds/ambrosia/gaia,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "laP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -10026,12 +13295,40 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lbN" = (
+/obj/item/pickaxe/drill,
+/obj/item/clothing/glasses/meson,
+/obj/structure/rack/shelf_metal,
+/obj/item/mining_scanner,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
+"lcA" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "lcD" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lcI" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Armory";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
+"lcK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "lcN" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
@@ -10103,6 +13400,19 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"lgd" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/enclave/rnd)
 "lgQ" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -10142,6 +13452,12 @@
 "lix" = (
 /turf/closed/wall/f13/store,
 /area/f13/mountain_bunker)
+"liD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/workbench/forge,
+/obj/item/stack/sheet/mineral/abductor/ten,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "ljr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10171,6 +13487,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/underground/cave)
+"llA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "llB" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10192,6 +13515,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"llY" = (
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "lmv" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall/f13vault{
@@ -10347,6 +13676,9 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"lvU" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "lwy" = (
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -10354,6 +13686,11 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"lwV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "lxk" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -10394,6 +13731,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
+"lym" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "lyn" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10458,6 +13799,14 @@
 /obj/item/lipstick/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lCr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
 "lCs" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "stockpilebunker";
@@ -10507,6 +13856,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"lEn" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	req_access_txt = "134"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "lEF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10524,6 +13885,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"lFe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "lFh" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10588,6 +13956,13 @@
 /obj/item/reagent_containers/food/snacks/burger/fish,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"lHm" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lIO" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -10596,6 +13971,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"lIV" = (
+/obj/item/screwdriver/power,
+/obj/item/wirecutters/power,
+/obj/item/storage/toolbox/electrical,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/multitool/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "lJv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/shrapnel,
@@ -10616,9 +14001,8 @@
 	},
 /area/f13/caves)
 "lKi" = (
-/turf/closed/mineral/random/low_chance,
-/turf/closed/indestructible/rock,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "lKu" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10659,6 +14043,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"lLG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "lMg" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/f13/wood,
@@ -10697,6 +14085,10 @@
 "lOD" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/city)
+"lOP" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "lPa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10715,6 +14107,9 @@
 /obj/structure/junk/small/disco,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"lPH" = (
+/turf/open/water,
+/area/f13/enclave/prison)
 "lPS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10749,6 +14144,13 @@
 	dir = 4
 	},
 /area/f13/vault)
+"lRl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "lRv" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -10791,6 +14193,10 @@
 /mob/living/simple_animal/hostile/renegade/guardian/shotgunner,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"lTc" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "lTB" = (
 /obj/structure/debris/v1{
 	pixel_x = -16
@@ -10811,6 +14217,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"lUd" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/enclave)
 "lUH" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
@@ -10857,6 +14269,10 @@
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/bunker)
+"lWw" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "lWA" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -10875,12 +14291,26 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"lXe" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"lXg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
 "lXp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"lXv" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "lXz" = (
 /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /obj/structure/closet/secure_closet/goodies{
@@ -10947,6 +14377,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"maM" = (
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/briefing)
 "maT" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -10973,6 +14411,22 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"mbF" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/locker,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/restraints/legcuffs,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/key/collar,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
+"mcd" = (
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "mci" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/desert,
@@ -10980,6 +14434,21 @@
 "mcC" = (
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
+"mcS" = (
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/briefing)
+"mdb" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "mdi" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/porta_turret/syndicate{
@@ -11025,6 +14494,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"mgG" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/flashlight/lamp{
+	light_color = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "mhm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -11032,6 +14510,21 @@
 /obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"mho" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "miu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11044,6 +14537,34 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"mjh" = (
+/obj/structure/guncase,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/shoes/combat/coldres,
+/obj/item/clothing/shoes/combat/coldres,
+/obj/item/clothing/shoes/combat/coldres,
+/obj/item/clothing/shoes/combat/coldres,
+/obj/item/clothing/shoes/combat/coldres,
+/obj/item/clothing/shoes/combat/coldres,
+/obj/item/clothing/suit/hooded/wintercoat/durathread,
+/obj/item/clothing/suit/hooded/wintercoat/durathread,
+/obj/item/clothing/suit/hooded/wintercoat/durathread,
+/obj/item/clothing/suit/hooded/wintercoat/durathread,
+/obj/item/clothing/suit/hooded/wintercoat/durathread,
+/obj/item/clothing/suit/hooded/wintercoat/durathread,
+/obj/item/clothing/under/syndicate/coldres,
+/obj/item/clothing/under/syndicate/coldres,
+/obj/item/clothing/under/syndicate/coldres,
+/obj/item/clothing/under/syndicate/coldres,
+/obj/item/clothing/under/syndicate/coldres,
+/obj/item/clothing/under/syndicate/coldres,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "mjj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11058,6 +14579,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"mkk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/ketchup{
+	pixel_x = -2;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/food/snacks/nugget,
+/obj/item/reagent_containers/food/snacks/nugget,
+/obj/item/reagent_containers/food/snacks/nugget,
+/obj/item/reagent_containers/food/snacks/nugget,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/mess)
 "mku" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13{
@@ -11073,6 +14607,23 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
+"mlt" = (
+/obj/item/pickaxe/drill,
+/obj/item/clothing/glasses/meson,
+/obj/structure/rack/shelf_metal,
+/obj/item/mining_scanner,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
+"mlx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/right,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"mlA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "mlU" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -11080,6 +14631,12 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault)
+"mmn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "mmL" = (
 /obj/structure/decoration/cctv,
 /turf/closed/indestructible/riveted{
@@ -11105,6 +14662,13 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"mnC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "mnE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11177,6 +14741,14 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/ahs)
+"mqB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "mqP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
@@ -11190,6 +14762,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"mrb" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters/old{
+	id = "enc_brig_shutters";
+	name = "security shutter"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "mrD" = (
 /turf/closed/indestructible/riveted{
 	desc = "A heavily reinforced utility tunnel  wall. You doubt anything short of a nuke would break it.";
@@ -11208,6 +14791,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"mso" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/mess)
 "msu" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -11235,6 +14823,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"mto" = (
+/obj/structure/grille/broken,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "mua" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -11314,6 +14911,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"myv" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/gloves/combat,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/shoes/combat,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/alt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "myz" = (
 /obj/machinery/shower{
 	dir = 8
@@ -11397,6 +15010,16 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
+"mBx" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Barracks";
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "mBE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/sosjerky,
@@ -11417,6 +15040,26 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"mDd" = (
+/obj/structure/decoration/vent/rusty,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "mDr" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
@@ -11448,6 +15091,15 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"mER" = (
+/obj/machinery/light/small/broken{
+	light_color = "#F5CDA6"
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/bundle/weapon/piperifle,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/wasteland)
 "mFe" = (
 /obj/structure/table,
 /obj/item/storage/fancy/rollingpapers,
@@ -11458,6 +15110,12 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"mFm" = (
+/obj/structure/sign/poster/official/anniversary_vintage_reprint{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "mFG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/concrete,
@@ -11465,6 +15123,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"mGj" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "mGx" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/bot,
@@ -11477,6 +15139,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"mGY" = (
+/obj/structure/sign/poster/contraband/pinup_pink{
+	pixel_x = -31
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "mHk" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
@@ -11507,6 +15177,17 @@
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mHX" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
+"mIu" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "mID" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -11569,6 +15250,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mNC" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "mNJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "stockpilebunker";
@@ -11602,6 +15287,51 @@
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"mPj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Gunnery Sergeant's Quarters";
+	req_one_access_txt = "134";
+	id_tag = "gysgtquarters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"mPR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"mPV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/enclave)
+"mQg" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
+"mQB" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/enclave/hallways)
 "mQN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -11623,6 +15353,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"mRv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	req_one_access_txt = "134"
+	},
+/obj/machinery/door/window,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave)
 "mRP" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11643,12 +15382,20 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"mSm" = (
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "mSR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"mTi" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/enclave,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "mTm" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/command.dmi';
@@ -11659,6 +15406,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"mTp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/computer/security/enclave{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "mTL" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Science";
@@ -11669,6 +15425,28 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"mTQ" = (
+/obj/structure/guncase,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "mTW" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/barber{
@@ -11703,6 +15481,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"mWi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/decoration/fire{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "mWk" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11744,6 +15529,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"mZn" = (
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "mZp" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -11812,6 +15602,11 @@
 	},
 /turf/open/floor/plasteel/caution,
 /area/f13/vault)
+"ncI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "ndp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11819,6 +15614,13 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/radiation)
+"ndD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave)
 "ndE" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -11832,6 +15634,26 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ndS" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1
+	},
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/storage/backpack/satchel/enclave,
+/obj/item/clothing/head/f13/enclave/peacekeeper,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
+"new" = (
+/obj/structure/chair/right,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"nft" = (
+/obj/structure/sign/poster/prewar/poster80,
+/turf/closed/wall/r_wall,
+/area/f13/enclave/vertibird)
 "nfw" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/snacks/salad/ricepork,
@@ -11917,6 +15739,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"nil" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/dresser,
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
 "nio" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -11934,11 +15761,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"njq" = (
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
+"njJ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "njL" = (
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13,
 /area/f13/city)
+"nkx" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "nlG" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -12010,6 +15853,20 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nnW" = (
+/obj/structure/curtain,
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "noh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12029,12 +15886,36 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/f13,
 /area/f13/wasteland)
+"noY" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
+"npe" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -13
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "nph" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"npR" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "npV" = (
 /obj/effect/landmark/start/f13/vaultdoctor,
 /obj/structure/cable{
@@ -12059,6 +15940,15 @@
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nqF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "nrb" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/barber{
@@ -12066,6 +15956,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"nre" = (
+/obj/structure/chair/f13chair2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "nrT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/f13/blamco,
@@ -12088,6 +15984,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"nsA" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "nsN" = (
 /obj/item/target/alien,
 /obj/structure/chair/office/dark{
@@ -12120,6 +16024,28 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"nuv" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"nuw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
+"nuy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "nuD" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -12143,6 +16069,16 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"nvj" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "nwG" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -12219,6 +16155,10 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
+"nAb" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "nAe" = (
 /obj/structure/bookcase,
 /obj/structure/window/reinforced/tinted,
@@ -12227,6 +16167,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"nAo" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/enclave)
 "nAt" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/f13,
@@ -12243,6 +16192,13 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/ahs)
+"nBi" = (
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "nBF" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -12364,6 +16320,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"nGa" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
+"nGu" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "nGx" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
@@ -12373,6 +16340,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nHd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "nHv" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -12391,6 +16364,16 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"nHR" = (
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"nHS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "nJB" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/cleanable/greenglow/radioactive,
@@ -12433,6 +16416,13 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"nLO" = (
+/obj/structure/rack,
+/mob/living/simple_animal/mouse{
+	name = "Carl"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "nLW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12477,6 +16467,12 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"nNN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pizza/sassysage,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "nOl" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13{
@@ -12502,9 +16498,22 @@
 "nPG" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"nPO" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "nPZ" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
+"nQx" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "nRj" = (
 /obj/machinery/light{
 	dir = 8;
@@ -12555,6 +16564,11 @@
 /obj/item/reagent_containers/food/snacks/soup/beet,
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
+"nSX" = (
+/obj/machinery/vending/autodrobe,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "nTf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12639,6 +16653,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"nXa" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "nXb" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12670,6 +16692,20 @@
 /obj/item/stack/medical/gauze,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"nYd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/enclave/hallways)
 "nYn" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -12693,6 +16729,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"nZs" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "nZK" = (
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -12811,6 +16853,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"oey" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "oeB" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /mob/living/simple_animal/hostile/deathclaw/mother,
@@ -12839,6 +16885,12 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"ogx" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "ogz" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
@@ -12956,6 +17008,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"omH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"omS" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "ond" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/security.dmi';
@@ -12977,10 +17038,20 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/bunker)
+"onI" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "oon" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/ahs)
+"oor" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "oos" = (
 /obj/effect/decal/remains/human,
 /obj/item/flashlight/flare/torch,
@@ -13017,6 +17088,24 @@
 "oqm" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"oqp" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"oqM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
+"oqW" = (
+/obj/structure/target_stake{
+	anchored = 1
+	},
+/obj/item/target,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "orm" = (
 /mob/living/simple_animal/hostile/deathclaw{
 	desc = "One of the claw brothers.";
@@ -13045,6 +17134,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"osf" = (
+/obj/structure/sign/poster/sunset/sarsaparilla,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "osj" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt{
@@ -13059,6 +17152,15 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"osI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/corgi/Lisa,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "osJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -13066,6 +17168,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"osL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/bundle/weapon/piperifle,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
+"otr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/workbench/advanced,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "otL" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plasteel/f13{
@@ -13079,6 +17213,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"our" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Medical Bay";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius";
+	name = "vault floor"
+	},
+/area/f13/enclave)
 "out" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
@@ -13099,6 +17243,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"ouF" = (
+/obj/machinery/button/door{
+	id = "enc_brig_shutters";
+	name = "security shutters";
+	pixel_x = -26
+	},
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/prison)
 "ovo" = (
 /obj/machinery/door/unpowered/secure_steeldoor{
 	req_access_txt = "134"
@@ -13115,6 +17271,10 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"ovx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/prison)
 "ovC" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/turf_decal{
@@ -13122,6 +17282,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"owm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Private";
+	dir = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"owp" = (
+/obj/item/am_shielding_container,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/enclave/reactor)
 "owr" = (
 /obj/structure/chair{
 	dir = 8
@@ -13135,6 +17308,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
+"owF" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
+"oxh" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "oxn" = (
 /obj/structure/table,
 /obj/machinery/light/broken{
@@ -13167,6 +17352,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"ozq" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
+"ozN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "ozQ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/blood/drip,
@@ -13211,6 +17410,13 @@
 /obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"oBE" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "oBF" = (
 /obj/item/storage/box/emptysandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -13280,6 +17486,13 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"oEX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stock_parts/cell/ammo/mfc/overcharged{
+	anchored = 1
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "oEZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
@@ -13292,6 +17505,15 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/caves)
+"oFt" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/virology)
 "oFO" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel{
@@ -13330,6 +17552,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"oGz" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "oGD" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -13369,6 +17597,12 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"oHE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/left,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "oIa" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -13385,12 +17619,30 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/caves)
+"oIG" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/old{
+	id = "enc_brig_shutters";
+	name = "security shutter"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "oIS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"oJc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/hallways)
 "oJI" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/barber{
@@ -13410,6 +17662,20 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"oJW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"oKa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "oLr" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -13422,6 +17688,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
+"oLV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "oMc" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -13441,6 +17720,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"oMV" = (
+/obj/structure/toilet,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
+"oNc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/grass,
+/area/f13/enclave/hydroponics)
 "oNj" = (
 /obj/structure/chair/middle,
 /obj/item/radio/intercom{
@@ -13450,6 +17743,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"oNG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
+"oNH" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/f13/enclave)
 "oNP" = (
 /obj/machinery/light{
 	dir = 4;
@@ -13601,6 +17906,10 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
+"oTz" = (
+/obj/structure/fans/tiny/invisible,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "oTT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13672,6 +17981,13 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/f13/ahs)
+"oXp" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bathroom";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "oXV" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13690,6 +18006,37 @@
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oYV" = (
+/obj/machinery/button/door{
+	id = "pneumatic_door2";
+	name = "Primary Blastdoor";
+	pixel_y = 30
+	},
+/obj/machinery/button/door{
+	id = "pneumatic_door2t";
+	name = "Outer Blastdoor";
+	pixel_y = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"oYW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/button/door{
+	id = "pneumatic_door2t";
+	name = "Outer Blastdoor";
+	pixel_y = 40
+	},
+/obj/machinery/button/door{
+	id = "pneumatic_door2";
+	name = "Primary Blastdoor";
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
 "oZg" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -13755,6 +18102,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"pbR" = (
+/turf/open/floor/wood/wood_fancy/wood_fancy_dark,
+/area/f13/enclave)
 "pco" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 5
@@ -13883,6 +18233,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"pga" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "pgj" = (
 /obj/machinery/light{
 	dir = 1
@@ -13912,6 +18272,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/brotherhood)
+"phn" = (
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/radioterminal/enclave{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "pho" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
@@ -14031,6 +18405,24 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
+"pmO" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/locker,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/restraints/legcuffs,
+/obj/item/clothing/suit/straight_jacket,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/key/collar,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
 "pmZ" = (
 /obj/structure/sink{
 	dir = 1;
@@ -14098,6 +18490,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /turf/open/floor/plating,
 /area/f13/bunker)
+"prb" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Lieutenant's Quarters";
+	req_one_access_txt = "256";
+	id_tag = "ltquarters"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "prg" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14108,6 +18509,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"prh" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "prq" = (
 /obj/item/detective_scanner,
 /obj/structure/closet,
@@ -14135,6 +18543,16 @@
 /obj/machinery/door/unpowered/secure_NCR,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"prV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/left,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"psl" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "pte" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -14216,6 +18634,13 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"pwD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "pwG" = (
 /mob/living/simple_animal/hostile/handy/protectron{
 	health = 260;
@@ -14245,6 +18670,16 @@
 /obj/item/storage/box/emptysandbags,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"pAc" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/enclave)
 "pAq" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/floorgrime,
@@ -14293,10 +18728,40 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/ahs)
+"pDJ" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave/prison)
+"pDP" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/grenade/f13/plasma,
+/obj/item/grenade/f13/plasma,
+/obj/item/grenade/f13/incendiary,
+/obj/item/grenade/f13/incendiary,
+/obj/item/grenade/f13/frag,
+/obj/item/grenade/f13/frag,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "pDR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/f13/tunnel)
+"pDW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "pEe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/streak,
@@ -14343,6 +18808,10 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"pFU" = (
+/obj/structure/sign/departments/engineering,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "pFY" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plasteel/f13{
@@ -14369,6 +18838,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"pGL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/padded,
+/area/f13/enclave/prison)
 "pHa" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/floorgrime,
@@ -14424,6 +18897,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/bunker)
+"pJP" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
+"pKj" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/item/mop/advanced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "pKX" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/barber{
@@ -14435,6 +18922,13 @@
 /obj/item/clothing/under/shorts/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pLT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "pMc" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -14546,6 +19040,19 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"pOE" = (
+/obj/structure/rack,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/head/helmet/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/obj/item/clothing/suit/armor/f13/combat/enclave,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "pOG" = (
 /obj/structure/toilet{
 	dir = 1
@@ -14618,6 +19125,24 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"pQL" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/rack/shelf_metal,
+/obj/item/multitool,
+/obj/item/am_containment,
+/obj/item/screwdriver/power,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
+"pRd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "pRp" = (
 /obj/machinery/shower{
 	dir = 1
@@ -14658,12 +19183,29 @@
 /obj/structure/simple_door/metal/iron,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"pTL" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "pTT" = (
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"pTW" = (
+/obj/structure/table,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "pUh" = (
 /obj/structure/table/booth,
 /obj/machinery/light/small/broken{
@@ -14713,6 +19255,15 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"pVY" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/bundle/f13/autopipe,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
 "pWx" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/dirt{
@@ -14720,6 +19271,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pWB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/foamtank,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "pWC" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
@@ -14735,6 +19291,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"pXo" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "pXR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -14749,6 +19309,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"pYl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/concrete/ten,
+/obj/item/stack/sheet/mineral/concrete/ten,
+/obj/item/stack/sheet/mineral/concrete/five,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "pYx" = (
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -14776,6 +19343,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"pZv" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "pZC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -14837,6 +19410,10 @@
 /obj/effect/spawner/lootdrop/high_tools,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"qdL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/mess)
 "qdV" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/robot_debris,
@@ -14854,6 +19431,14 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"qes" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/loot_pile,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "qeM" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -14880,6 +19465,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"qfE" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "qfT" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -14909,6 +19498,13 @@
 /obj/effect/mob_spawn/human/corpse,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"qgY" = (
+/obj/machinery/light{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "qhb" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -14938,6 +19534,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"qit" = (
+/obj/machinery/button/door{
+	id = "bos_ps1"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "qiw" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -14951,6 +19553,23 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"qiJ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"qji" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/landmark/start/f13/uscpl,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "qjs" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden,
@@ -14968,6 +19587,21 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"qjy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/left{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
+"qjA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "qjF" = (
 /obj/structure/railing{
 	dir = 8
@@ -15047,6 +19681,17 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/vault)
+"qoQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/button/door{
+	id = "gysgtquarters";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave/command)
 "qpG" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/f13{
@@ -15188,6 +19833,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"qwu" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "qwL" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
@@ -15203,6 +19852,16 @@
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"qyl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "qyq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/shrapnel,
@@ -15230,6 +19889,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"qzn" = (
+/obj/structure/loot_pile,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "qzu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15255,6 +19923,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"qzU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/biohazard,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "qAP" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -15263,6 +19939,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"qAW" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "qBx" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30;
@@ -15331,12 +20016,31 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
+"qFp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "sgtoffices";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "qFs" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "qFG" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault)
+"qGs" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/armory)
 "qGH" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -15357,6 +20061,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"qHj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "qHp" = (
 /obj/structure/chair/f13foldupchair,
 /mob/living/simple_animal/hostile/renegade/defender/assaulter,
@@ -15429,6 +20141,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qJN" = (
+/obj/structure/curtain{
+	color = "red"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave)
 "qJQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15496,6 +20221,10 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"qNx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "qOe" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -15529,6 +20258,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"qQh" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/hooded/surgical,
+/obj/item/clothing/mask/surgical{
+	pixel_y = -4
+	},
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "qQz" = (
 /obj/structure/debris/v3{
 	layer = 2;
@@ -15565,6 +20303,20 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
+"qSa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = -32
+	},
+/obj/machinery/button/door{
+	id = "encroom3";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "qSc" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
@@ -15624,6 +20376,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
+"qTM" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "qTW" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/head/hardhat/orange,
@@ -15697,12 +20454,26 @@
 /obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"qXK" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/wasteland)
 "qXZ" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
+"qYl" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "qYI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker,
@@ -15789,6 +20560,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"rdK" = (
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "rdM" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -15810,6 +20588,10 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"reF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
 "rfU" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
@@ -15832,6 +20614,20 @@
 	name = "metal plating"
 	},
 /area/f13/bunker)
+"rgz" = (
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/closet/crate/mortar_shells,
+/obj/item/mortar_kit,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "rgF" = (
 /obj/machinery/door/poddoor/shutters{
 	name = "gate shutters"
@@ -15892,6 +20688,20 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"rkz" = (
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"rkI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "rkQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15916,6 +20726,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"rmg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "rmm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15940,6 +20754,16 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"ror" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"roC" = (
+/obj/structure/sign/poster/sunset/nukagirl,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "rqu" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -15953,6 +20777,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"rqU" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "rqZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15980,6 +20808,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"rsq" = (
+/obj/structure/decoration/vent/rusty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "rsr" = (
 /obj/structure/window/reinforced/spawner,
 /obj/effect/decal/cleanable/greenglow,
@@ -16015,6 +20857,17 @@
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"ruL" = (
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/pet/cat/kitten{
+	name = "encat";
+	health = 50;
+	faction = list("neutral","hostile","wastebot","enclave","BOS","deathclaw","supermutant");
+	maxHealth = 50;
+	desc = "You could imagine it meowing 'GOD BLESS AMERICA, OORAH' if it could. Instead, it just gives comically cute looks. It does have a tiny american flag dyed into its fur though, which is cool."
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "ruU" = (
 /obj/machinery/light{
 	dir = 1
@@ -16104,6 +20957,14 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"ryP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/loot_pile,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
 "rzh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/streak,
@@ -16139,6 +21000,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"rzY" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"rAa" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
 "rAt" = (
 /obj/machinery/door/airlock{
 	name = "Restrooms"
@@ -16200,6 +21068,17 @@
 	dir = 1
 	},
 /area/f13/vault)
+"rDp" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "rDA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
@@ -16240,6 +21119,16 @@
 /mob/living/simple_animal/hostile/renegade/defender/assaulter,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"rFv" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"rFO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "rGK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -16259,6 +21148,12 @@
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"rIe" = (
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "rIB" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16275,11 +21170,35 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"rIR" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "rJI" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"rKr" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
+"rKv" = (
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/briefing)
 "rKV" = (
 /obj/machinery/light/sign/kebab,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16308,10 +21227,39 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"rLD" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "rMA" = (
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"rMG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/engine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
+"rMJ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"rML" = (
+/obj/machinery/door/airlock/vault{
+	req_one_access_txt = "134"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "rMX" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -16336,6 +21284,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"rOB" = (
+/obj/machinery/door/window/right{
+	dir = 8;
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hydroponics)
 "rOZ" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -16390,6 +21346,16 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"rPV" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
+"rQi" = (
+/obj/effect/decal/cleanable/generic,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "rQt" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
@@ -16409,6 +21375,21 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"rRT" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/white/end{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "rSk" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
@@ -16419,6 +21400,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"rSm" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/item/stack/cable_coil/random/five,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
+"rSv" = (
+/obj/structure/sign/departments/botany,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "rSC" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
@@ -16477,6 +21467,32 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"rUt" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/computer/security/enclave{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
+"rUO" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/wasteland)
+"rUW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/decoration/fire,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "rVH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -16511,6 +21527,10 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/vault)
+"rXE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "rYk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
@@ -16520,6 +21540,16 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"rYq" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"rYw" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "rYK" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel,
@@ -16535,6 +21565,38 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"rZi" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
+"rZx" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"rZD" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
+"saG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "saL" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -16560,6 +21622,15 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"sbs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/obj/machinery/limbgrower,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "sbG" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small{
@@ -16621,6 +21692,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"sev" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 4
+	},
+/obj/machinery/harvester,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "seY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -16629,6 +21709,20 @@
 "sfc" = (
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"sfh" = (
+/turf/open/floor/carpet/black,
+/area/f13/enclave/command)
+"sfm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/card/enclave{
+	dir = 1;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "\improper Enclave identification terminal"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "sfq" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -16641,6 +21735,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"sfv" = (
+/obj/structure/chair/right,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "sfF" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/plasteel/barber{
@@ -16693,6 +21791,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"siE" = (
+/obj/machinery/light{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "siW" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -16764,6 +21869,15 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"smd" = (
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_y = 32
+	},
+/obj/machinery/camera/autoname{
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/hallways)
 "smj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
@@ -16856,6 +21970,11 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"sqM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/manned_turret/m2/unanchored,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "sqY" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -16867,6 +21986,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"srp" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = -32
+	},
+/obj/machinery/button/door{
+	id = "encroom2";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
+"srv" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "ssi" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16877,6 +22013,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"sso" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	id_tag = "encroom3"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "ssw" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -16919,6 +22062,26 @@
 	name = "metal plating"
 	},
 /area/f13/bunker)
+"sux" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"suK" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "bos_ps1";
+	name = "privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "suQ" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plating/tunnel{
@@ -16929,6 +22092,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"svQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "svZ" = (
 /obj/item/stack/crafting/electronicparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -16954,6 +22123,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/bunker)
+"swl" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "swu" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -17016,6 +22189,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"syG" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Enclave Outpost, Medical Bay"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "syS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
@@ -17116,6 +22297,10 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"sDw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "sDE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17126,6 +22311,34 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"sEI" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"sEP" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/light_emitter,
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/water,
+/area/f13/enclave/rnd)
+"sEX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "sFa" = (
 /obj/machinery/light{
 	dir = 8;
@@ -17135,6 +22348,17 @@
 	dir = 8
 	},
 /area/f13/vault)
+"sFo" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
+"sFG" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	id_tag = "encroom2"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "sFP" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -17142,6 +22366,25 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"sGe" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Canteen"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave)
+"sGo" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/table/glass,
+/obj/item/megaphone/sec,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "sGC" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/f13{
@@ -17156,6 +22399,13 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"sHb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "sHf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -17172,6 +22422,14 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"sIt" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "sIv" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13{
@@ -17220,6 +22478,17 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"sJG" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
+"sJJ" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "sKU" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -17230,11 +22499,26 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"sLw" = (
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -32
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "sLB" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
 /area/f13/bunker)
+"sMd" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "sMj" = (
 /obj/structure/barricade/concrete,
 /obj/effect/decal/cleanable/dirt,
@@ -17261,6 +22545,22 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"sPe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"sPo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "sQz" = (
 /turf/open/floor/f13,
 /area/f13/city)
@@ -17296,6 +22596,13 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/ahs)
+"sSc" = (
+/obj/machinery/light{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "sSf" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -17304,6 +22611,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/ahs)
+"sSy" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "sSR" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "stockpilebunker";
@@ -17330,6 +22641,16 @@
 /obj/item/flag/renegade,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sTQ" = (
+/obj/structure/table,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "sUw" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -17376,6 +22697,12 @@
 	dir = 8
 	},
 /area/f13/vault)
+"sXm" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "sXN" = (
 /obj/item/crafting/abraxo,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
@@ -17498,6 +22825,10 @@
 	dir = 8
 	},
 /area/f13/vault)
+"tdh" = (
+/obj/structure/wreck/trash/secway,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "tdk" = (
 /mob/living/simple_animal/hostile/renegade/smasher,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
@@ -17541,6 +22872,16 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
+"teO" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/mess)
+"tfe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "tfn" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/f13/wood,
@@ -17566,11 +22907,43 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"tfP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	name = "Lobster room"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "tgh" = (
 /obj/structure/table,
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"tgi" = (
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/msgterminal/enclave{
+	density = 1;
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "tgJ" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17596,6 +22969,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"tht" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "tib" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -17659,12 +23040,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"tlR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "tmI" = (
 /obj/machinery/door/airlock{
 	name = "Bar Backroom"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"tnc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"tnk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "tnp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17675,6 +23083,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"tnT" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
+"tor" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "tot" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -17754,6 +23181,22 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"trJ" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/obj/machinery/button/door{
+	id = "enct2";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "tsa" = (
 /obj/machinery/door/airlock/security{
 	name = "Barracks";
@@ -17761,12 +23204,36 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"tsM" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	id_tag = "encvirology"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/virology)
 "tto" = (
 /obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask,
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"ttz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/button/door{
+	id = "sstaffoffices";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "ttV" = (
 /obj/structure/chair/bench,
 /mob/living/simple_animal/hostile/renegade/guardian/shotgunner,
@@ -17798,6 +23265,28 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"tuT" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter/gold{
+	desc = "A shiny and relatively expensive zippo lighter. There's a small etched in verse on the bottom that reads, 'God Bless the Enclave and Nobody Else.'"
+	},
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 34
+	},
+/obj/item/clothing/head/helmet/f13/power_armor/t60/bos{
+	armor = list();
+	anchored = 1;
+	pixel_y = 32;
+	name = "Trophy BOS T-60a power helmet";
+	desc = "A T-60a helmet with the sigil of the Brotherhood of Steel marked on the side. This one is stripped of all actual armour, serving as a decorative ornament"
+	},
+/obj/item/storage/lockbox/medal{
+	req_access_txt = "256"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "tvn" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden,
@@ -17868,12 +23357,34 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"tyN" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"tyP" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"tzq" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "tzP" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"tAq" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "tAB" = (
 /obj/machinery/workbench/advanced,
 /obj/item/stack/ore/blackpowder/five,
@@ -17891,6 +23402,38 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"tBk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"tBD" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
+"tCk" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "tCu" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
@@ -17931,6 +23474,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"tDH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "tED" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plasteel/barber{
@@ -17956,11 +23506,45 @@
 "tEV" = (
 /turf/open/floor/plasteel,
 /area/f13/vault)
+"tFf" = (
+/obj/item/flag/enclave/america,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"tFg" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"tFm" = (
+/obj/structure/curtain,
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "tFv" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/renegade/defender/assaulter,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"tGa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Enclave Outpost, Armory"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "tGF" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/radiation,
@@ -17990,6 +23574,16 @@
 "tGX" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/city)
+"tHd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "ltquarters";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "tHs" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 30
@@ -17999,12 +23593,27 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"tHU" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/decoration/vent,
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "tHX" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"tHY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "tIh" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -18044,6 +23653,11 @@
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"tJB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "tJJ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18079,6 +23693,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"tLw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "tLA" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -18129,6 +23750,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"tOw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "tOS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -18147,12 +23772,36 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"tPt" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/meatballspaghetti,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "tPQ" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"tPW" = (
+/obj/structure/rack,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/item/flashlight/flare/emergency,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "tQd" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
@@ -18173,6 +23822,23 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/ahs)
+"tQB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
+"tRv" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
+"tST" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window/right,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "tSV" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/barber{
@@ -18200,6 +23866,14 @@
 	},
 /turf/closed/wall/f13/vault,
 /area/f13/brotherhood)
+"tUj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "tUm" = (
 /obj/machinery/light/small{
 	light_color = "#ad1b1b"
@@ -18251,6 +23925,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"tWX" = (
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "tXf" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -18278,6 +23960,18 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"tYY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "tZf" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/smasher,
@@ -18330,10 +24024,22 @@
 	},
 /turf/open/floor/f13,
 /area/f13/city)
+"uby" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
 "ubM" = (
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ubW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "ucf" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -18397,6 +24103,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"ugk" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "ugp" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/barber{
@@ -18561,6 +24277,23 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/f13/ahs)
+"uly" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/wasteland)
+"ume" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
 "umF" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "stockpilebunker";
@@ -18579,6 +24312,14 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/caves)
+"une" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "unj" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -18603,6 +24344,15 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"upk" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "upn" = (
 /obj/structure/grille,
 /obj/structure/simple_door/metal/ventilation,
@@ -18610,6 +24360,13 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"upD" = (
+/obj/machinery/door/poddoor/gate/bunker{
+	id = "pneumatic_door2t"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
 "upG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -18683,6 +24440,23 @@
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"usM" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/innerchp)
+"utc" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/water,
+/area/f13/enclave/prison)
 "utD" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/uranium{
@@ -18749,6 +24523,10 @@
 	icon_state = "redmark"
 	},
 /area/f13/legion)
+"uuM" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "uuZ" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/barber{
@@ -18766,6 +24544,10 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"uwy" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/carpet/black,
+/area/f13/enclave/command)
 "uwM" = (
 /obj/machinery/shower{
 	dir = 4
@@ -18791,6 +24573,20 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uxL" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
+"uyt" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Gunnery Sergeant's Office";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "uyA" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -18799,6 +24595,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"uyO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "uyZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18835,6 +24636,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"uzD" = (
+/obj/item/am_shielding_container,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/enclave/reactor)
+"uAb" = (
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/mess)
 "uAm" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution{
@@ -18896,6 +24709,26 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"uCG" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/cookie,
+/obj/item/reagent_containers/food/snacks/cookie{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/cookie{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/chocolatebar{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/snacks/cola_float{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "uCU" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18974,6 +24807,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"uGn" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
+"uGC" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "uGI" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -19007,6 +24853,13 @@
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"uHH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "uHR" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -19037,6 +24890,29 @@
 	name = "Reinforced utility tunnel"
 	},
 /area/f13/caves)
+"uJe" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/item/detective_scanner,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"uJk" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/spawner/lootdrop/f13/traitbooks/low,
+/obj/effect/spawner/lootdrop/f13/traitbooks/low,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "uJu" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -19051,6 +24927,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"uJI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "uJZ" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -19064,6 +24945,10 @@
 /obj/structure/chair/left,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"uKx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "uKB" = (
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
@@ -19133,6 +25018,15 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"uOw" = (
+/obj/machinery/vending/coffee{
+	layer = 4.15
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "uOD" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -19151,6 +25045,32 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/vault)
+"uQb" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"uQi" = (
+/obj/structure/table/reinforced,
+/obj/item/stamp/captain{
+	name = "overseer's rubber stamp";
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/pen/fountain/captain{
+	desc = "It's an expensive Oak fountain pen, engraved with the numbers 113. The nib is quite sharp.";
+	name = "overseer's fountain pen";
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "uQB" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/f13{
@@ -19176,11 +25096,28 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"uRg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/frame/machine,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/enclave)
 "uRG" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"uRJ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "uRK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/low_tools,
@@ -19223,6 +25160,12 @@
 	dir = 1
 	},
 /area/f13/vault)
+"uTz" = (
+/obj/machinery/light/floor,
+/obj/machinery/plantgenes,
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "uTA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/tunnel,
@@ -19232,6 +25175,11 @@
 	dir = 4
 	},
 /area/f13/vault)
+"uTL" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "uTS" = (
 /obj/machinery/light{
 	dir = 4
@@ -19322,10 +25270,24 @@
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"uXx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "uXK" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"uYa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "uYb" = (
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
@@ -19354,6 +25316,12 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"uYs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "uYt" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -19362,6 +25330,19 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"uYT" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/obj/machinery/button/door{
+	id = "encvirology";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "uZG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19378,6 +25359,16 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/ahs)
+"van" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Exterior Camera";
+	network = list("Enclave");
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "vap" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -19406,6 +25397,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"vbk" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "vbp" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -19414,6 +25414,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"vby" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vbG" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -19424,6 +25432,16 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vbY" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/ore_box,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
 "vch" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/light{
@@ -19439,6 +25457,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"vcv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
+"vcE" = (
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
 "vcN" = (
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
@@ -19448,6 +25477,13 @@
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"vep" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "ves" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 4
@@ -19483,6 +25519,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"vfO" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "vfQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19503,6 +25543,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"vhb" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Sergeant's Quarters";
+	req_one_access_txt = "134";
+	id_tag = "sgtoffices"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "vhc" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility/full/engi,
@@ -19516,6 +25565,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"vhw" = (
+/mob/living/simple_animal/cow/brahmin,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/grass,
+/area/f13/enclave/hydroponics)
 "vhy" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -19528,6 +25585,26 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"vhE" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
+"vie" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1
+	},
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/storage/backpack/satchel/enclave,
+/obj/item/clothing/head/f13/enclave/peacekeeper,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/under/f13/enclave/peacekeeper,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "vil" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -19545,6 +25622,13 @@
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
+"vir" = (
+/obj/item/soap/deluxe,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "viy" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/medspray{
@@ -19681,6 +25765,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/mountain_bunker)
+"vmz" = (
+/obj/structure/decoration/vent,
+/turf/open/water,
+/area/f13/enclave/prison)
 "vmL" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -19729,6 +25817,17 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"vpF" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/razor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "vpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19740,6 +25839,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"vqm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"vqt" = (
+/obj/item/clothing/mask/gas/enclave,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "vqH" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
@@ -19829,12 +25944,29 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"vtM" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/prison)
 "vuu" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"vuI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/dresser,
+/obj/item/pda/heads/hos,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/enclave/command)
 "vuT" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
@@ -19855,6 +25987,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"vxf" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/old{
+	id = "enc_brig_shutters";
+	name = "security shutter"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/prison)
 "vxh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -19914,16 +26060,32 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"vzH" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "vzR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"vAA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "vAB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"vAK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/innerchp)
 "vAT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -19971,12 +26133,28 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
+"vBY" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "vCf" = (
 /mob/living/simple_animal/hostile/renegade/soldier{
 	retreat_distance = null
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vCj" = (
+/obj/machinery/door/airlock/vault{
+	req_one_access_txt = "134"
+	},
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "vCq" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -20044,11 +26222,24 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"vIn" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "vIr" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/benedict,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"vIs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Private";
+	dir = 0;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "vIU" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -20086,10 +26277,26 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/caves)
+"vKu" = (
+/obj/machinery/light/floor{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
+"vKx" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "vLu" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"vLE" = (
+/obj/structure/bed,
+/obj/item/bedsheet/enclave,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "vMb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -20149,6 +26356,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"vPD" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "vPN" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -20160,6 +26371,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"vQk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "vQu" = (
 /obj/machinery/water_purifier{
 	density = 0;
@@ -20193,20 +26411,53 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"vRM" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/enclave)
 "vSd" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
+"vSD" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "vSI" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution,
 /area/f13/vault)
+"vSN" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
+"vSO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet,
+/turf/open/floor/carpet/black,
+/area/f13/enclave)
 "vSU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
 /mob/living/simple_animal/hostile/renegade/guardian/shotgunner,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker)
+"vTh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/enclave)
+"vTl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "vUs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20220,6 +26471,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
+"vVU" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "vWJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20297,12 +26552,30 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"vZi" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
 "vZk" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
 	},
 /area/f13/city)
+"wak" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"waM" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "wba" = (
 /mob/living/simple_animal/hostile/renegade/engie/breacher,
 /turf/open/floor/f13/wood,
@@ -20372,10 +26645,35 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"wdH" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "wdL" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"wdR" = (
+/obj/structure/decoration/vent/rusty,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "wfk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -20401,6 +26699,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"wgI" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/enclave)
 "wgQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -20416,12 +26719,36 @@
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plating,
 /area/f13/bunker)
+"whG" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/enclave)
 "wia" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"win" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
+"wiz" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/security/enclave,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "wiK" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/brown,
@@ -20432,6 +26759,13 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"wjm" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Chemical Lab";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "wjN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -20443,6 +26777,17 @@
 "wjV" = (
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
+"wkp" = (
+/obj/structure/sign/poster/official/safety_report,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"wkG" = (
+/obj/structure/fans/tiny,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "reinforced wall";
+	icon = 'icons/turf/walls/reinforced_wall.dmi'
+	},
+/area/f13/enclave)
 "wkK" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/barber{
@@ -20499,6 +26844,14 @@
 	dir = 1
 	},
 /area/f13/bunker)
+"wnq" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134";
+	name = "Reactor"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave)
 "wnA" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -20549,6 +26902,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/f13/bunker)
+"woJ" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "wpc" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20573,6 +26930,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
+"wpu" = (
+/obj/structure/dresser,
+/obj/item/clothing/head/HoS/beret/syndicate{
+	name = "officer's beret"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/f13/enclave/command)
 "wqw" = (
 /turf/open/floor/f13{
 	icon_state = "yellowsiding"
@@ -20586,6 +26950,22 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"wrl" = (
+/obj/structure/table/reinforced,
+/obj/item/card/id/dogtag/enclave/officer{
+	pixel_x = -5
+	},
+/obj/item/card/id/dogtag/enclave/officer{
+	pixel_x = -5
+	},
+/obj/item/card/id/dogtag/enclave/trooper{
+	pixel_x = 7
+	},
+/obj/item/card/id/dogtag/enclave/trooper{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/enclave/command)
 "wrT" = (
 /obj/machinery/computer/security{
 	network = list("vault")
@@ -20678,6 +27058,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"www" = (
+/obj/machinery/light/floor{
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "wxN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20690,6 +27077,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"wxQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chalkboard,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "wxT" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
@@ -20719,12 +27114,39 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
+"wzf" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave)
+"wzz" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
+/obj/effect/spawner/lootdrop/weapons/oldarmy,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "wzB" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 6
 	},
 /area/f13/vault)
+"wzF" = (
+/obj/machinery/door/airlock/hatch{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Support Staff's Quarters";
+	req_one_access_txt = "134";
+	id_tag = "sstaffoffices"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "wzK" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -20839,6 +27261,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"wFr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "wFQ" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
@@ -20857,6 +27286,16 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/caves)
+"wIp" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "wIV" = (
 /obj/item/storage/toolbox/emergency/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20892,6 +27331,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"wKO" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/virology)
 "wKP" = (
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plasteel/freezer,
@@ -20951,6 +27393,10 @@
 	dir = 9
 	},
 /area/f13/vault)
+"wOR" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/medbay)
 "wPz" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/item/radio/intercom{
@@ -21023,6 +27469,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
+"wSI" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "wTk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21033,6 +27487,15 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
+"wTy" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "wTB" = (
 /obj/structure/sink{
 	dir = 8;
@@ -21118,6 +27581,12 @@
 "wWG" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/legion)
+"wWK" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "wWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21212,6 +27681,15 @@
 /obj/item/clothing/head/helmet/f13/raidermetal,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"wZc" = (
+/obj/structure/sign/departments/examroom,
+/turf/closed/wall/r_wall,
+/area/f13/enclave)
+"wZx" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/wasteland)
 "wZW" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -21219,6 +27697,16 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"xan" = (
+/obj/machinery/workbench,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "xaJ" = (
 /obj/machinery/porta_turret/syndicate{
 	faction = list("raider","hostile","ghoul","supermutant")
@@ -21228,10 +27716,28 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/city)
+"xbg" = (
+/obj/structure/closet/wardrobe/virology_white,
+/obj/machinery/light{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "xbi" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xbk" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "xbp" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -21239,6 +27745,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"xbR" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
 "xbU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21256,6 +27766,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"xcs" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
+"xcz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 19
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "xdq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -21284,6 +27817,17 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker)
+"xej" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/briefing)
 "xfc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/steak,
@@ -21298,6 +27842,18 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/ncr)
+"xfV" = (
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/enclave/hallways)
+"xgs" = (
+/obj/structure/decoration/vent,
+/obj/item/fishy/lobster,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Enclave")
+	},
+/turf/open/water,
+/area/f13/enclave/prison)
 "xgO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -21315,6 +27871,14 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"xhw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/vertibird)
 "xim" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13{
@@ -21375,6 +27939,31 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"xkt" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/crafting/coffee_pot{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee/enclave{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacocoa/enclave{
+	pixel_x = -10;
+	pixel_y = -6;
+	layer = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instatea/enclave{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "xkI" = (
 /obj/structure/grille,
 /obj/structure/simple_door/metal/ventilation,
@@ -21383,6 +27972,9 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"xle" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/wasteland)
 "xls" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 1;
@@ -21395,6 +27987,10 @@
 /obj/item/stack/sheet/plastic/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"xma" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/innerchp)
 "xmb" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21404,6 +28000,13 @@
 	dir = 4
 	},
 /area/f13/vault)
+"xmE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
 "xmP" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -21470,6 +28073,22 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"xqz" = (
+/obj/structure/target_stake{
+	anchored = 1
+	},
+/obj/item/target,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#F5CDA6";
+	bulb_colour = "#F5CDA6"
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "xqG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -21518,6 +28137,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"xsl" = (
+/obj/structure/table,
+/obj/item/toy/tennis,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "xsw" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Research Storage";
@@ -21549,6 +28173,13 @@
 /obj/item/storage/box/stockparts/deluxe,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
+"xtr" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/enclave/rnd)
 "xtP" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21593,6 +28224,32 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"xwU" = (
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
+"xwV" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/armory)
 "xxb" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -21601,6 +28258,12 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"xxK" = (
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/armory)
 "xxX" = (
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/f13{
@@ -21657,6 +28320,16 @@
 	},
 /turf/open/floor/f13,
 /area/f13/city)
+"xCj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/enclave/rnd)
+"xCK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "xCW" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -21695,6 +28368,13 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"xFs" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/virology)
 "xFL" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -21704,6 +28384,23 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"xFN" = (
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"xFP" = (
+/obj/structure/chair/left,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/fruit_bowl{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "xFU" = (
 /obj/structure/table,
 /obj/item/clothing/suit/toggle/labcoat/f13/followers,
@@ -21742,6 +28439,36 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"xHb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	network = list("Enclave");
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
+"xHh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/pizzabox/meat,
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 8
+	},
+/obj/structure/sign/plaques/kiddie{
+	desc = "A faded sign listing all the less-than-healthy fast foods that were sold here before the war";
+	name = "fast food menu";
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/enclave/mess)
+"xHl" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave)
 "xHp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -21786,6 +28513,18 @@
 "xIt" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"xIE" = (
+/turf/closed/indestructible/f13vaultrusted{
+	name = "reinforced wall";
+	icon = 'icons/turf/walls/reinforced_wall.dmi'
+	},
+/area/f13/enclave)
+"xJy" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
 "xJQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21813,6 +28552,14 @@
 /obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"xLt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/machinery/computer/security/enclave{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "xLF" = (
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/barber{
@@ -21853,6 +28600,23 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xOe" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/enclave)
+"xOh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
 "xOq" = (
 /obj/structure/cable,
 /obj/item/radio/intercom{
@@ -21897,6 +28661,16 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"xQu" = (
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/enclave/briefing)
 "xQF" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/barber{
@@ -21909,6 +28683,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"xRn" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/enclave/mess)
 "xRI" = (
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/dark,
@@ -21946,6 +28724,24 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"xTl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"xTM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
 "xTO" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -21974,6 +28770,19 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"xUM" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/enclave/reactor)
 "xWe" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/simple_door/room,
@@ -21994,10 +28803,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"xWD" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/enclave/virology)
 "xXY" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plating,
 /area/f13/bunker)
+"xYl" = (
+/obj/structure/sign/departments/custodian,
+/turf/closed/wall/r_wall/rust,
+/area/f13/enclave)
 "xYo" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22045,6 +28863,13 @@
 "yde" = (
 /turf/closed/wall/mineral/wood,
 /area/f13/underground/cave)
+"ydt" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/hallways)
 "ydL" = (
 /obj/structure/junk/locker,
 /turf/open/floor/f13{
@@ -22074,6 +28899,19 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"yeg" = (
+/turf/open/floor/mineral/plastitanium,
+/area/f13/enclave)
+"yem" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/enclave)
 "yew" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -22102,6 +28940,15 @@
 	},
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
+"yfI" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/enclave/mess)
 "yfZ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -22115,6 +28962,15 @@
 /obj/structure/closet,
 /turf/open/floor/f13,
 /area/f13/city)
+"ygT" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/enclave/command)
+"yhb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/command)
 "yhh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22162,6 +29018,13 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"yjW" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Briefing Room";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/enclave/briefing)
 "ykp" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	minimum_distance = 2
@@ -22170,6 +29033,16 @@
 	icon_state = "redmark"
 	},
 /area/f13/bunker)
+"ykA" = (
+/obj/structure/bodycontainer/crematorium{
+	id = "enc_crem"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/enclave/medbay)
+"ykN" = (
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/enclave/hydroponics)
 "ykZ" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plasteel/barber{
@@ -22177,6 +29050,27 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"yls" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave/vertibird)
+"ylG" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/enclave)
 "ylH" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -48568,8 +55462,8 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
+bVH
+bVH
 bVH
 bVH
 bVH
@@ -48610,17 +55504,17 @@ xpR
 bVH
 cQP
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
 ldZ
 aTA
 aTA
@@ -48814,21 +55708,21 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
 aTA
 aTA
 aTA
@@ -48868,16 +55762,16 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
 ldZ
 aTA
 aTA
@@ -49071,6 +55965,21 @@ aTA
 aTA
 aTA
 aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
 aTA
 aTA
 aTA
@@ -49110,31 +56019,16 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
 ldZ
 aTA
 aTA
@@ -49328,6 +56222,42 @@ shC
 shC
 shC
 shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
 shC
 shC
 shC
@@ -49345,54 +56275,18 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
 shC
 shC
 shC
@@ -49585,71 +56479,71 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+apv
+apv
+apv
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+shC
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
 shC
 shC
 shC
@@ -49842,71 +56736,71 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+ylG
+rQi
+cCC
+sSy
+vcE
+cwx
+aRn
+lOP
+vcE
+vSO
+cyl
+vcE
+ylG
+vcE
+shC
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
 shC
 shC
 shC
@@ -50099,73 +56993,73 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+iLR
+tLw
+emu
+emu
+vcE
+aRn
+lKi
+xHb
+vcE
+emu
+emu
+tLw
+apR
+vcE
+shC
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
 shC
 dTc
 iVr
@@ -50356,73 +57250,73 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+gFM
+vcE
+fIn
+pDW
+jUX
+tOw
+lKi
+tOw
+sFG
+mHX
+fIn
+gFM
+vcE
+vcE
+shC
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
 shC
 dTc
 iVr
@@ -50613,73 +57507,73 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+nil
+dRa
+vhE
+iGk
+vcE
+lKi
+lKi
+tOw
+vcE
+aNQ
+qHj
+pbR
+esm
+vcE
+shC
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
 shC
 dTc
 iVr
@@ -50870,73 +57764,73 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+bms
+lCr
+dkV
+uXx
+fZU
+lKi
+lKi
+ktF
+vcE
+uXx
+srp
+lCr
+lXg
+vcE
+shC
+aTA
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
 shC
 dTc
 dTc
@@ -51127,73 +58021,73 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bLI
+dTu
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+vcE
+vcE
+fZU
+fZU
+noY
+bGs
+tOw
+vKx
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+shC
+aTA
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
 shC
 shC
 shC
@@ -51384,74 +58278,74 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+vrM
+xpR
+xpR
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+lnj
+aTA
+lnj
+aTA
+aTA
+shC
+vcE
+ndS
+ivw
+eUM
+ndS
+fZU
+lKi
+iVD
+crB
+fZU
+sSy
+cCC
+vcE
+tYY
+vcE
+shC
+aTA
+aTA
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+jex
+uuM
 shC
 shC
 shC
@@ -51642,74 +58536,74 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+xpR
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+lnj
+lnj
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+mGj
+bJJ
+fNW
+fNW
+vcE
+lKi
+iVD
+lKi
+fZU
+fIn
+emu
+kwF
+apR
+vcE
+shC
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+iLg
+goA
+goA
+hrZ
 shC
 shC
 shC
@@ -51900,73 +58794,73 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+dYn
+ndS
+gpB
+nQx
+bJJ
+wzf
+lKi
+lKi
+tOw
+sso
+eWX
+emu
+gFM
+gFM
+vcE
+shC
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+bVH
+bVH
+bVH
+iLg
+goA
+goA
+hrZ
+hrZ
 shC
 shC
 shC
@@ -52158,72 +59052,72 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+jEl
+uly
+lWw
+lWw
+lWw
+rUO
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+nSX
+fNW
+fNW
+fNW
+vcE
+lKi
+lKi
+tOw
+vcE
+jFT
+qHj
+dRa
+esm
+vcE
+shC
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+iLg
+goA
+goA
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -52414,6 +59308,22 @@ shC
 shC
 shC
 shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
 shC
 shC
 shC
@@ -52433,6 +59343,21 @@ shC
 shC
 shC
 shC
+fZU
+vie
+gdH
+akd
+ndS
+vcE
+ktF
+tOw
+aRn
+fZU
+uXx
+qSa
+lCr
+lXg
+vcE
 shC
 shC
 shC
@@ -52444,43 +59369,12 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+uuM
+goA
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -52670,74 +59564,74 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+lnj
+aTA
+aTA
+shC
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+fbU
+fZU
+vcE
+fZU
+vcE
+vcE
+ero
+vcE
+vcE
+dYn
+vcE
+fZU
+vcE
+fZU
+vcE
+vcE
+vcE
+fZU
+vKx
+aRn
+ecF
+fZU
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+fZU
+fZU
+vcE
+vcE
+fZU
+vcE
+fZU
+fZU
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -52926,75 +59820,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+cJy
+kaG
+bVH
+bVH
+bRc
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+oMV
+npe
+jkS
+vcE
+vTl
+kro
+qgY
+fZU
+vLE
+eJZ
+xLt
+lXv
+vcE
+lXv
+xLt
+eJZ
+vLE
+fZU
+vLE
+prh
+owm
+lvU
+fZU
+crB
+tOw
+kWd
+fZU
+lvU
+vIs
+prh
+vLE
+roC
+vcE
+btV
+gtS
+tPW
+fZU
+sJJ
+aPa
+fZU
+vir
+rKr
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -53183,75 +60077,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+vcE
+oXp
+gFM
+oEX
+dZf
+isV
+pLT
+fZU
+agb
+eHh
+lvU
+omH
+vcE
+kro
+kro
+tUj
+qFp
+fZU
+omS
+hNF
+lym
+kWB
+fZU
+lKi
+lKi
+lKi
+vcE
+gDa
+awM
+dbr
+eJZ
+vcE
+vcE
+pXo
+tyN
+gtS
+fZU
+gtS
+gtS
+fZU
+sPo
+njq
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -53440,75 +60334,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+vuI
+sfh
+uwy
+vcE
+oYV
+mTi
+eEK
+fZU
+awM
+lym
+vBY
+kro
+vcE
+kro
+vBY
+lym
+awM
+fZU
+fdQ
+lvU
+vBY
+njJ
+krI
+lKi
+tOw
+lKi
+wzF
+lvU
+eEK
+kro
+mTp
+vcE
+vcE
+uCG
+jCE
+iVw
+uxL
+jCE
+gtS
+fZU
+vSD
+nHR
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -53697,75 +60591,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+ero
+dwZ
+awa
+qoQ
+mPj
+yhb
+gjC
+kro
+fZU
+dbZ
+jgc
+kro
+eWl
+vcE
+lvU
+lvU
+jgc
+bCg
+fZU
+lXv
+kOW
+lvU
+lvU
+vcE
+dah
+tOw
+lKi
+vcE
+yhb
+kro
+ttz
+win
+vcE
+vcE
+eHB
+jCE
+gtS
+gvZ
+jCE
+jCE
+uxL
+gtS
+jCE
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -53954,75 +60848,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+vcE
+fZU
+fZU
+vcE
+vcE
+vcE
+uyt
+fZU
+fZU
+fZU
+cfP
+vcE
+vcE
+vcE
+vhb
+vcE
+fZU
+fZU
+fZU
+fZU
+vcE
+vcE
+vcE
+uQb
+lKi
+tOw
+vcE
+fZU
+fZU
+fZU
+vcE
+vcE
+vcE
+aHi
+jCE
+jCE
+fZU
+nPO
+woJ
+fZU
+iZs
+yls
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -54211,75 +61105,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+shC
+fZU
+glj
+dVX
+jkc
+aHv
+nAo
+bGs
+lKi
+lKi
+lKi
+lKi
+lKi
+lKi
+tOw
+tOw
+tOw
+tOw
+tOw
+lKi
+lKi
+lKi
+lKi
+tOw
+jfL
+aSm
+lKi
+lKi
+vcE
+rUt
+phn
+tgi
+sGo
+vcE
+vcE
+jju
+fZU
+wWK
+fZU
+fZU
+fZU
+fZU
+fZU
+fZU
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -54468,75 +61362,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+hhS
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+aTA
+shC
+fZU
+fNW
+qjA
+fNW
+fNW
+nAo
+tOw
+tOw
+lKi
+lKi
+tOw
+kWd
+lKi
+lKi
+lKi
+lKi
+lKi
+tOw
+tOw
+tOw
+lKi
+lKi
+lKi
+lKi
+lKi
+lKi
+lKi
+gvZ
+oey
+oey
+iMt
+oey
+vcE
+nft
+pWB
+hlR
+hlR
+wWK
+hlR
+cBv
+xCK
+hlR
+woJ
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -54725,75 +61619,75 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+aTA
+lnj
+lnj
+aTA
+lnj
+shC
+fZU
+fNW
+nAb
+kBk
+bJJ
+hxJ
+lKi
+lKi
+tOw
+kso
+kWd
+kWd
+tOw
+tOw
+jLH
+lKi
+lKi
+lKi
+lKi
+kWd
+pTL
+lKi
+lKi
+tOw
+tOw
+tOw
+lKi
+fZU
+iMt
+jYd
+xQu
+oey
+vcE
+lXe
+tzq
+hlR
+hlR
+fZU
+upk
+cxr
+hzx
+hns
+nLO
+fZU
+shC
+shC
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -54982,75 +61876,75 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+aTA
+lnj
+lnj
+lnj
+lnj
+aTA
+aTA
+aTA
+lnj
+aTA
+aTA
+lnj
+shC
+fZU
+ncI
+hYr
+dRl
+cgg
+vcE
+lKi
+qwu
+tOw
+vcE
+fZU
+fZU
+fZU
+wnq
+vcE
+vcE
+vcE
+uRJ
+jYA
+jYA
+svQ
+svQ
+svQ
+jYA
+jwU
+lKi
+tOw
+fZU
+iMt
+haD
+maM
+iMt
+vcE
+gtS
+uYa
+hlR
+hlR
+fZU
+fZU
+jHV
+jHV
+fZU
+gvZ
+fZU
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -55239,75 +62133,75 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iLg
+iLg
+iLg
+iLg
+uuM
+aTA
+aTA
+lnj
+lnj
+aTA
+lnj
+lnj
+aTA
+aTA
+lnj
+aTA
+aTA
+aTA
+shC
+fZU
+iju
+dey
+llA
+bHD
+vcE
+lKi
+lKi
+tOw
+vcE
+sIt
+tFm
+fZU
+ozN
+baR
+ozN
+oLV
+sHb
+nZs
+eeB
+dQe
+fZU
+vhw
+jVd
+aPg
+lKi
+tOw
+vcE
+iMt
+mcS
+rKv
+iMt
+wWK
+psl
+oJW
+une
+oJW
+tnk
+dfY
+aFG
+ejw
+aFG
+oJW
+bVs
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -55495,96 +62389,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+rqU
+rqU
+rqU
+rqU
+uuM
+lnj
+lnj
+lnj
+lnj
+aTA
+aTA
+lnj
+lnj
+lnj
+aTA
+aTA
+aTA
+aTA
+shC
+vcE
+tST
+tDH
+bJJ
+oxh
+vcE
+tOw
+lKi
+lKi
+vcE
+jTl
+nnW
+fZU
+xbk
+jYA
+gYJ
+tCk
+jGQ
+xUM
+eeB
+tBD
+vcE
+jdc
+oNc
+aPg
+lKi
+tOw
+yjW
+waM
+atc
+oey
+waM
+qit
+lwV
+vKu
+sDw
+irz
+irz
+sDw
+sDw
+bMp
+irz
+vKu
+vqm
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -55752,96 +62646,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+iLg
+iLg
+iLg
+iLg
+uuM
+lnj
+lnj
+lnj
+lnj
+lnj
+lnj
+aTA
+aTA
+aTA
+aTA
+shC
+shC
+shC
+shC
+vcE
+onI
+xmE
+iJB
+efD
+fZU
+lKi
+tOw
+lKi
+vcE
+ubW
+nnW
+fZU
+sHb
+ceq
+cyG
+bPn
+cyG
+pga
+eeB
+cFv
+vcE
+cLh
+jkt
+aPg
+tOw
+tOw
+vcE
+xej
+ayC
+tnT
+rDp
+dRd
+lwV
+irz
+irz
+irz
+irz
+sDw
+sDw
+irz
+irz
+irz
+vqm
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -56009,96 +62903,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+bVH
+bVH
+bVH
+bVH
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+lnj
+lnj
+lnj
+lnj
+shC
+vcE
+fZU
+vcE
+vcE
+vcE
+vcE
+fZU
+fZU
+fZU
+tlR
+lKi
+lKi
+vcE
+wTy
+nnW
+vcE
+xwU
+nqF
+owp
+owp
+owp
+aVB
+ozN
+pQL
+xIE
+eZQ
+rOB
+nHd
+lKi
+lKi
+fZU
+kqG
+ibV
+jyb
+qji
+suK
+lwV
+irz
+irz
+irz
+irz
+irz
+irz
+sDw
+irz
+irz
+vqm
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -56266,96 +63160,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+qXK
+hjY
+wZx
+wZx
+jDO
+shC
+vcE
+vcE
+vcE
+vcE
+shC
+shC
+shC
+shC
+shC
+shC
+fZU
+fMt
+fSO
+fSO
+fSO
+gPS
+fMt
+gPS
+dCJ
+lKi
+lKi
+lKi
+vcE
+hFy
+fXg
+xIE
+xIE
+xIE
+uzD
+owp
+fbB
+xIE
+kCf
+cFH
+xIE
+vcE
+bHg
+mQg
+tnc
+kQR
+svQ
+svQ
+svQ
+daq
+jYA
+qAW
+lwV
+sDw
+sDw
+irz
+irz
+irz
+irz
+sDw
+irz
+irz
+vqm
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -56523,96 +63417,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+xle
+xle
+xle
+jNC
+lTc
+oTz
+vcE
+kmz
+fBc
+vcE
+vcE
+vcE
+vcE
+vcE
+jju
+fZU
+fZU
+eJl
+gPS
+hiR
+asb
+fSO
+fSO
+eJl
+vcE
+lKi
+tOw
+tOw
+vcE
+iqB
+iqB
+kEF
+imW
+wkG
+owp
+owp
+owp
+xIE
+dsI
+www
+uYs
+uYs
+tht
+tJB
+lKi
+lKi
+fZU
+mto
+pKj
+uRg
+bGH
+mmn
+lwV
+irz
+sDw
+sDw
+irz
+irz
+irz
+bMp
+sDw
+irz
+vqm
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -56780,96 +63674,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+xle
+xle
+xle
+ekx
+bzU
+upD
+iwd
+ume
+iUj
+vAK
+bIN
+qes
+ume
+gky
+qyl
+gPS
+uby
+gPS
+fSO
+hiR
+pYl
+fSO
+asb
+nBi
+vcE
+lKi
+lKi
+rFv
+vcE
+vpF
+eJi
+vcE
+vcE
+xIE
+xIE
+hAs
+xIE
+xIE
+vVU
+ykN
+rZi
+ijy
+ykN
+aeJ
+tOw
+lKi
+lcK
+mnC
+jCa
+hOe
+hfx
+mmn
+lwV
+irz
+irz
+sDw
+irz
+eLZ
+irz
+irz
+irz
+irz
+vqm
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -57037,96 +63931,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+xle
+xle
+xle
+ekx
+van
+xma
+fav
+pVY
+iUj
+ksd
+vSN
+osL
+ume
+gky
+usM
+eyu
+hkl
+gPS
+gPS
+hiR
+sqM
+fSO
+asb
+fSO
+vcE
+lKi
+lKi
+lKi
+vcE
+vpF
+jTl
+gfM
+trJ
+fXg
+hqu
+hqu
+hqu
+vcE
+laH
+rXE
+uYs
+uYs
+kTb
+fMW
+lKi
+bbC
+rLD
+cfA
+gsJ
+aFi
+iYo
+nHd
+lwV
+irz
+irz
+sDw
+bMp
+irz
+irz
+irz
+irz
+irz
+vqm
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -57294,96 +64188,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+xle
+xle
+xle
+mER
+lTc
+oTz
+vcE
+fMj
+etU
+vcE
+vcE
+vcE
+vcE
+vcE
+jju
+jHV
+jHV
+rkI
+gPS
+asb
+hiR
+gPS
+eJl
+gPS
+vcE
+lKi
+lKi
+lKi
+vcE
+iVu
+iGa
+vcE
+vcE
+fZU
+ghV
+vRM
+ghV
+ugk
+nGu
+ykN
+tHY
+tHY
+rXE
+jHV
+lKi
+tOw
+xYl
+bTV
+fZU
+rUW
+fZU
+nHd
+lwV
+irz
+irz
+irz
+irz
+irz
+irz
+irz
+irz
+irz
+mqB
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -57551,96 +64445,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+wZx
+jDO
+qXK
+wZx
+hjY
+shC
+vcE
+vcE
+vcE
+vcE
+shC
+shC
+shC
+shC
+shC
+shC
+jHV
+gXi
+rkI
+hXl
+gPS
+eJl
+usM
+fSO
+dCJ
+tOw
+tOw
+lKi
+vcE
+jTl
+iqB
+aAd
+gbn
+gvZ
+vRM
+vRM
+vRM
+ugk
+fWl
+ykN
+jxo
+jxo
+kTb
+rFO
+tOw
+lKi
+dDT
+dhq
+kLk
+ews
+rzY
+nHd
+lwV
+irz
+irz
+irz
+irz
+irz
+irz
+irz
+irz
+irz
+vqm
+jHV
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -57808,96 +64702,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+bVH
+bVH
+bVH
+bVH
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+hrZ
+iba
+hrZ
+shC
+vcE
+fZU
+fZU
+fZU
+fZU
+fZU
+vcE
+fXg
+vcE
+vcE
+tlR
+lKi
+lKi
+gFM
+oXp
+laG
+vcE
+vcE
+vcE
+pZv
+cCa
+dpp
+fZU
+fZU
+anQ
+ykN
+ykN
+fNc
+vcE
+nuy
+tOw
+pRd
+dhq
+csH
+csH
+dhq
+nHd
+lwV
+sDw
+sDw
+irz
+irz
+sDw
+bLF
+sDw
+irz
+irz
+vqm
+ugk
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -58065,96 +64959,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+iba
+iba
+hrZ
+iba
+hrZ
+hrZ
+iba
+iba
+shC
+shC
+vcE
+tdh
+mGY
+iHg
+pAc
+lRl
+aVK
+gRQ
+rMG
+vcE
+lKi
+lKi
+lKi
+tBk
+tOw
+lKi
+lKi
+lKi
+kif
+lKi
+tOw
+kWd
+uOw
+fZU
+cvS
+xan
+ykN
+uTz
+vcE
+lKi
+lKi
+pRd
+csH
+dhq
+jMA
+blY
+nHd
+dHF
+xhw
+sDw
+sDw
+irz
+sDw
+irz
+irz
+irz
+vKu
+vqm
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -58322,96 +65216,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
 hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
+iba
+iba
+iba
+iba
+hrZ
+shC
+vcE
+vcE
+coU
+fpM
+vTh
+jCa
+xOe
+lRl
+fpM
+ryP
+mBx
+tOw
+tOw
+lKi
+lKi
+tOw
+tOw
+tOw
+lKi
+tOw
+lKi
+lKi
+lKi
+kWd
+fZU
+fZU
+rSv
+bHg
+bDO
+vcE
+lKi
+lKi
+cjB
+wIp
+dhq
+csH
+tWX
+mmn
+rYq
+wFr
+wFr
+wFr
+wFr
+wFr
+iMX
+xTM
+iMX
+wFr
+lFe
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -58579,17 +65473,8 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -58599,76 +65484,85 @@ hrZ
 hrZ
 hrZ
 iba
+iba
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+vcE
+dYn
+ruL
+mPV
+iph
+uKx
+nHS
+gRQ
+fEQ
+lUd
+fZU
+rMJ
+swl
+tFg
+nre
 lKi
+lKi
+lKi
+lKi
+lKi
+lKi
+tOw
+lKi
+lKi
+lKi
+kif
+lKi
+lKi
+lKi
+lKi
+lKi
+tOw
+jhz
+csH
+dhq
+csH
+dov
+mmn
+vcE
+vcE
+vcE
+sEX
+vcE
+rLD
+jHV
+jHV
+fZU
+fZU
+vcE
+vcE
+shC
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -58836,96 +65730,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
 iba
+iba
+iba
+iba
+iba
+shC
+shC
+shC
+vcE
+fZU
+nHS
+jZm
+qfE
+qzn
+eSW
+fZU
+lcK
+lcK
+vcE
+vcE
+fZU
+fZU
+fZU
+fZU
+fZU
+fZU
+cvd
+vcE
+jju
+tOw
+lKi
+lKi
+lKi
+lKi
+lKi
+lKi
+tOw
+tOw
+lKi
+tOw
+sPe
+csH
+dhq
+csH
+jva
+aXw
+eej
+jaE
+vIn
+xbg
+vcE
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -59093,23 +65987,65 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
+iba
+iba
+iba
+iba
+iba
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+vcE
+ugk
+vcE
+vcE
+fZU
+fZU
+fZU
+fZU
+fZU
+vcE
+vcE
+vcE
+vcE
+dHH
+jtR
+lLG
+kNl
+fXg
+vqt
+nXa
+cZV
+dpV
+sEX
+xFN
+tOw
+tOw
+lKi
+lKi
+lKi
+lKi
+tOw
+tOw
+lKi
+tOw
+sPe
+csH
+csH
+csH
+rSm
+aXw
+xFs
+vIn
+vIn
+jpW
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -59121,68 +66057,26 @@ hrZ
 iba
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -59350,23 +66244,65 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
+iba
+iba
+iba
+iba
+iba
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+ugk
+vZi
+ddy
+cFW
+fZU
+uJe
+wak
+fNg
+epe
+vcE
+kyI
+qQh
+elz
+mdb
+dHH
+dHH
+dHH
+kCl
+dHH
+dHH
+fJr
+ciV
+ndD
+lKi
+lKi
+lKi
+gvZ
+fZU
+agr
+agr
+hjC
+fZU
+dah
+bYa
+sPe
+csH
+csH
+csH
+jVW
+aXw
+gPH
+vIn
+vIn
+jaE
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -59378,68 +66314,26 @@ hrZ
 iba
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -59607,74 +66501,65 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
 iba
-hrZ
+iba
 iba
 hrZ
 hrZ
+shC
+vcE
+ava
+lLG
+lLG
+hgE
+dHH
+lLG
+lLG
+lLG
+vcE
+gmL
+lLG
+elz
+lLG
+dHH
+lLG
+dHH
+wjm
+dHH
+lLG
+fJr
+wOR
+mRv
+lKi
+tOw
+rFv
+fZU
+oNG
+fva
+fva
+wgI
+fZU
+lKi
+tOw
+lgd
+sEP
+osf
+vcE
+cjB
+mmn
+abn
+vIn
+vIn
+jaE
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -59686,17 +66571,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -59864,43 +66758,65 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
 iba
 hrZ
 hrZ
+shC
+vcE
+ykA
+mdb
+dHH
+lLG
+dHH
+lLG
+dHH
+grZ
+vcE
+oqp
+dHH
+gvG
+dHH
+dHH
+nkx
+fYm
+cAS
+jwz
+oBE
+rZD
+kEI
+sEX
+lKi
+tOw
+lKi
+fZU
+lIV
+fva
+fva
+iSL
+fZU
+lKi
+tOw
+aSv
+hMP
+wxQ
+xsl
+xtr
+aXw
+bUS
+vIn
+vIn
+jaE
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -59912,48 +66828,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -60121,96 +67015,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
-hrZ
+iba
+iba
 iba
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+fZU
+lLG
+lLG
+dHH
+lLG
+lLG
+mdb
+dHH
+lLG
+wZc
+kwT
+kwT
+gKP
+dHH
+lLG
+gxm
+tQB
+fZU
+fZU
+sEX
+sEX
+sEX
+sEX
+jxV
+lKi
+lKi
+vcE
+iJq
+fva
+fva
+uGC
+fZU
+tlR
+tOw
+bzy
+fLn
+hpE
+npR
+hiP
+aXw
+jaE
+vIn
+vIn
+vIn
+bVi
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -60378,96 +67272,96 @@ iba
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+iba
+iba
+iba
+iba
+hrZ
+shC
+shC
+fZU
+sTQ
+sev
+agd
+kzV
+ror
+rIR
+rIR
+xTl
+dHj
+lLG
+dHH
+sLw
+dHH
+lLG
+sbs
+tQB
+mIu
+tOw
+lKi
+lKi
+lKi
+rZx
+lKi
+lKi
+tOw
+vcE
+kHK
+mlA
+fva
+liD
+vcE
+lKi
+tOw
+jhz
+dhq
+csH
+csH
+csH
+aXw
+gTD
+alq
+uYT
+cNo
+vcE
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
 iba
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -60635,50 +67529,65 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
+iba
+iba
+iba
+hrZ
+shC
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+gLW
+dHH
+dHH
+dHH
+lLG
+lLG
+etV
+ydt
+lKi
+kWd
+lKi
+tOw
+lKi
+lKi
+lKi
+lKi
+agr
+fva
+fva
+kNS
+mWi
+fZU
+lKi
+lKi
+jhz
+dhq
+osI
+dBs
+qTM
+mmn
+vcE
+vcE
+vcE
+tsM
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -60690,41 +67599,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -60892,59 +67786,68 @@ hrZ
 hrZ
 hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
 iba
 hrZ
+shC
+vcE
+oMV
+ifv
+gaP
+vcE
+rAa
+rAa
+reF
+reF
+pJP
+vcE
+dHH
+abu
+cxd
+dHH
+lLG
+eSP
+our
+lKi
+jfL
+lKi
+vAA
+vAA
+saG
+vAA
+vAA
+lKi
+pFU
+vcE
+fXg
+vcE
+vcE
+fZU
+lKi
+tOw
+jhz
+uJI
+csH
+csH
+rkz
+qzU
+xWD
+xWD
+xWD
+azN
+vcE
+shC
 hrZ
 hrZ
 hrZ
-iba
 hrZ
 hrZ
 hrZ
@@ -60953,35 +67856,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -61149,55 +68043,65 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 iba
+iba
+iba
+iba
+hrZ
+shC
+vcE
+vcE
+oXp
+vcE
+vcE
+oYW
+wrl
+uTL
+rAa
+rAa
+vcE
+syG
+sEI
+gfn
+hls
+fTu
+kFX
+sEX
+lKi
+lKi
+lKi
+tQB
+fZU
+fZU
+fZU
+lcK
+vcE
+vcE
+iUk
+qNx
+hdM
+fZU
+new
+tOw
+tOw
+sPe
+csH
+csH
+csH
+csH
+oFt
+azN
+azN
+wKO
+kOL
+fZU
+shC
 hrZ
 hrZ
 hrZ
@@ -61209,36 +68113,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -61406,96 +68300,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+vcE
+fyJ
+bEv
+vcE
+jsk
+ygT
+rAa
+uQi
+dyH
+rAa
+vcE
+tFf
+fZU
+tQB
+vcE
+vcE
+sEX
+kUg
+lKi
+lKi
+rFv
+fZU
+sfv
+kux
+qjy
+edZ
+nuw
+ihx
+ihx
+ihx
+cRq
+vcE
+prV
+lKi
+tOw
+jhz
+jFb
+ejV
+csH
+mFm
+dAW
+xWD
+xWD
+xWD
+wKO
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -61663,7 +68557,65 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+vcE
+jzN
+sXm
+vcE
+kJo
+rAa
+edA
+sfm
+rAa
+rAa
+fUG
+gNa
+gNa
+gNa
+lKi
+lKi
+rZx
+icG
+tOw
+lKi
+tOw
+sEX
+xFP
+tPt
+llY
+asR
+ihx
+aaO
+nNN
+rmg
+hFc
+uRJ
+oKa
+oKa
+oKa
+jYA
+hAe
+hRY
+jkn
+jYA
+gUD
+fZU
+fZU
+fZU
+tfP
+fZU
+shC
 hrZ
 hrZ
 hrZ
@@ -61675,84 +68627,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -61920,96 +68814,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+vcE
+tuT
+gHa
+vcE
+hlq
+rAa
+rAa
+aes
+xJy
+ygT
+iDv
+sux
+sux
+sux
+lKi
+tOw
+lKi
+lKi
+tOw
+lKi
+tOw
+sGe
+ihx
+rmg
+rmg
+ihx
+rmg
+aaO
+dcT
+rmg
+xkt
+mmn
+tOw
+lKi
+lKi
+cjB
+dMA
+dMA
+iJI
+jYh
+fPu
+vmz
+bQf
+lPH
+jMJ
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -62177,16 +69071,8 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
+shC
+shC
 hrZ
 hrZ
 iba
@@ -62196,77 +69082,85 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+vcE
+wpu
+gHa
+vcE
+vcE
+gxj
+mho
+kZu
+reF
+rAa
+qJN
+tOw
+tOw
+tOw
+bYa
+tOw
+mQB
+cLS
+mlx
+tOw
+tOw
+sEX
+xRn
+jVE
+lcA
+jVE
+rmg
+aaO
+xcz
+cHA
+vfO
+mmn
+mPR
+lKi
+tOw
+vcE
+iRq
+dMA
+bCR
+dMA
+fPu
+lPH
+lPH
+iQz
+lPH
+gvZ
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -62434,96 +69328,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 iba
-hrZ
-hrZ
 iba
-hrZ
-hrZ
 iba
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+vcE
+kUj
+gHa
+tHd
+prb
+rAa
+reF
+reF
+rAa
+pJP
+nHd
+vcE
+vcE
+aWo
+gFM
+lKi
+kyP
+nYd
+oHE
+lKi
+tOw
+sEX
+sEX
+xHh
+dGx
+mkk
+teO
+gRL
+sEX
+sEX
+etV
+nHd
+lKi
+tOw
+tOw
+vcE
+nvj
+dMA
+iJI
+koo
+oNH
+vmz
+bQf
+utc
+xgs
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -62691,39 +69585,65 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
 iba
 hrZ
 hrZ
 hrZ
 hrZ
+shC
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+fZU
+fZU
+fZU
+fZU
+nHd
+vzH
+ijL
+iqB
+gFM
+tOw
+tOw
+tOw
+tOw
+lKi
+lKi
+hpm
+sEX
+teO
+qdL
+teO
+mso
+etV
+hOa
+feu
+yfI
+nHd
+lKi
+lKi
+tOw
+eIs
+dMA
+xCj
+dMA
+vep
+vcE
+fZU
+fZU
+fZU
+vcE
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -62735,52 +69655,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -62948,10 +69842,65 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+vcE
+fZU
+oqW
+xqz
+oqW
+nHd
+ozq
+wSI
+tHU
+gFM
+lKi
+tOw
+tfe
+tOw
+lKi
+lKi
+ibB
+sEX
+uAb
+akG
+jMt
+qdL
+xcs
+jYS
+xOh
+tRv
+nHd
+lKi
+lKi
+lKi
+vcE
+igm
+dCZ
+iJI
+xbR
+vcE
+shC
+shC
+shC
+shC
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -62963,81 +69912,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -63205,9 +70099,12 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
-hrZ
+iba
+iba
 iba
 hrZ
 hrZ
@@ -63217,20 +70114,45 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
 iba
+shC
+vcE
+fZU
+vQk
+oqM
+oqM
+qiJ
+svQ
+svQ
+jYA
+jYA
+jYA
+iLY
+chu
+ijs
+ijs
+svQ
+svQ
+uHH
+jYA
+tor
+jYA
+svQ
+svQ
+svQ
+jYA
+jYA
+nuv
+tOw
+lKi
+tOw
+vcE
+kVO
+dCZ
+iJI
+rdK
+gvZ
+shC
 hrZ
 hrZ
 hrZ
@@ -63247,54 +70169,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -63462,20 +70356,8 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -63490,47 +70372,44 @@ hrZ
 hrZ
 hrZ
 iba
-hrZ
-hrZ
-iba
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+vcE
+vcE
+uGn
+oqM
+uGn
+vcE
+mTQ
+mjh
+ats
+cVU
+xwV
+wdH
+vcE
+oJc
+xfV
+fZU
+knH
+hnY
+nGa
+vxf
+nGa
+hnY
+eXY
+vcE
+fjG
+vcE
+ibB
+lKi
+lKi
+jfL
+fZU
+tAq
+dCZ
+jDe
+jDe
+fZU
+shC
 hrZ
 hrZ
 hrZ
@@ -63547,11 +70426,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -63719,8 +70613,13 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
@@ -63729,6 +70628,45 @@ hrZ
 hrZ
 hrZ
 hrZ
+iba
+shC
+vcE
+vcE
+oGz
+oqM
+uGn
+hRC
+uGn
+oqM
+oqM
+uGn
+uGn
+uGn
+vcE
+smd
+cqM
+vcE
+ium
+pGL
+pGL
+vxf
+pGL
+pGL
+agK
+fZU
+cOm
+vcE
+aXp
+oor
+jfL
+jfL
+fZU
+dcX
+sMd
+pwD
+pTW
+fZU
+shC
 hrZ
 hrZ
 hrZ
@@ -63745,70 +70683,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -63976,33 +70870,11 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
 iba
 iba
 hrZ
@@ -64013,33 +70885,45 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
 iba
+shC
+vcE
+fZU
+rIe
+mZn
+mZn
+vcE
+xxK
+oqM
+oqM
+uGn
+uGn
+siE
+vcE
+xfV
+oJc
+vcE
+agF
+mcd
+agF
+vxf
+agF
+mcd
+ogx
+fZU
+fZU
+fZU
+fZU
+fZU
+ewj
+fZU
+fZU
+fZU
+fZU
+yem
+yem
+vcE
+shC
 hrZ
 hrZ
 hrZ
@@ -64056,16 +70940,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -64233,51 +71127,12 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
 iba
 hrZ
 hrZ
@@ -64287,6 +71142,45 @@ hrZ
 hrZ
 hrZ
 hrZ
+mSm
+shC
+vcE
+qGs
+fDc
+fDc
+fDc
+vcE
+oqM
+wzz
+myv
+ija
+kcP
+uGn
+vcE
+pDJ
+dhx
+vcE
+mrb
+lEn
+oIG
+jRR
+dtw
+lEn
+ksV
+fZU
+vcv
+vbk
+rYw
+fZU
+yeg
+yeg
+yeg
+sJG
+lbN
+yem
+shC
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -64303,26 +71197,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -64490,8 +71384,13 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
@@ -64500,6 +71399,43 @@ hrZ
 hrZ
 hrZ
 hrZ
+mSm
+shC
+vcE
+ftU
+rgz
+uGn
+uGn
+fxH
+uGn
+kJW
+pOE
+sFo
+fpV
+uGn
+vcE
+aXZ
+ovx
+vcE
+aXZ
+aXZ
+aXZ
+ouF
+ovx
+aXZ
+aXZ
+fZU
+gWD
+bze
+frf
+vcE
+dny
+frV
+jfe
+yeg
+mlt
+fZU
+shC
 hrZ
 hrZ
 hrZ
@@ -64508,6 +71444,7 @@ hrZ
 hrZ
 hrZ
 hrZ
+iba
 hrZ
 hrZ
 hrZ
@@ -64517,69 +71454,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -64747,6 +71641,66 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+iba
+iba
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+mSm
+shC
+vcE
+gFM
+fVz
+uGn
+oqM
+uGn
+uGn
+oqM
+uGn
+uGn
+uGn
+oqM
+lcI
+aXZ
+ovx
+jsI
+ovx
+ovx
+aXZ
+ovx
+aXZ
+aXZ
+ovx
+rPV
+rYw
+vtM
+mgG
+vcE
+vbY
+frV
+frV
+yeg
+sSc
+fZU
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+iba
 iba
 hrZ
 hrZ
@@ -64757,86 +71711,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -65004,9 +71898,65 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+mSm
+shC
+vcE
+vcE
+pDP
+xxK
+uGn
+oqM
+uGn
+uGn
+oqM
+uGn
+uGn
+srv
+hxr
+iAC
+aXZ
+vcE
+aXZ
+aXZ
+ovx
+aXZ
+ovx
+aXZ
+aXZ
+fZU
+rYw
+flU
+afh
+vcE
+kCq
+yeg
+frV
+dip
+uyO
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+iba
 iba
 hrZ
 hrZ
@@ -65018,82 +71968,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -65261,6 +72155,13 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
@@ -65269,38 +72170,49 @@ hrZ
 hrZ
 hrZ
 hrZ
+mSm
+shC
+vcE
+wkp
+owF
+uGn
+uGn
+uGn
+uGn
+oqM
+bjb
+tGa
+cFd
+uGn
+vcE
+cvF
+hxf
+agk
+mbF
+pmO
+dSe
+ftm
+jHp
+pmO
+mbF
+fZU
+xHl
+jHV
+ero
+vcE
+fZU
+vCj
+fZU
+vcE
+vcE
+vcE
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
 iba
 hrZ
 hrZ
@@ -65312,45 +72224,27 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -65518,60 +72412,11 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
 iba
 iba
 hrZ
@@ -65582,6 +72427,43 @@ hrZ
 hrZ
 hrZ
 hrZ
+mSm
+shC
+vcE
+vcE
+uJk
+rRT
+otr
+bBR
+bIZ
+mNC
+wiz
+qYl
+nsA
+czZ
+fZU
+fZU
+fZU
+vcE
+vcE
+fZU
+fZU
+fZU
+fZU
+fZU
+fZU
+vcE
+vcE
+gFM
+vcE
+fZU
+rsq
+kwt
+mDd
+fZU
+shC
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -65600,14 +72482,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -65775,36 +72669,13 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
@@ -65813,6 +72684,41 @@ iba
 hrZ
 hrZ
 hrZ
+mSm
+shC
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+noY
+whG
+fZU
+vcE
+vcE
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+fZU
+eXB
+jTC
+wdR
+fZU
+shC
 hrZ
 hrZ
 hrZ
@@ -65833,38 +72739,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -66032,6 +72926,58 @@ iba
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+iba
+iba
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+mSm
+shC
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+vcE
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+nlT
+dvv
+akL
+dvv
+dvv
+fZU
+eXB
+cLW
+gDg
+fZU
+hrZ
+hrZ
+hrZ
 hrZ
 hrZ
 hrZ
@@ -66050,78 +72996,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -66289,6 +73183,58 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+nlT
+nlT
+dvv
+dvv
+nlT
+fZU
+vPD
+rML
+vPD
+fZU
+hrZ
+hrZ
+hrZ
 hrZ
 hrZ
 hrZ
@@ -66306,79 +73252,27 @@ iba
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
 iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -66546,22 +73440,13 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
 hrZ
 hrZ
 hrZ
@@ -66587,12 +73472,23 @@ hrZ
 hrZ
 hrZ
 iba
+iba
+iba
+hrZ
+hrZ
+iba
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
+nlT
+nlT
+nlT
+nlT
+lHm
+vby
+nlT
+vby
+nlT
 hrZ
 hrZ
 hrZ
@@ -66610,32 +73506,30 @@ hrZ
 hrZ
 iba
 hrZ
-iba
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -66803,19 +73697,17 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
@@ -66838,6 +73730,34 @@ hrZ
 hrZ
 iba
 hrZ
+iba
+hrZ
+hrZ
+hrZ
+iba
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+nlT
+nlT
+tyP
+tyP
+tyP
+nlT
+nlT
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 hrZ
 hrZ
 iba
@@ -66847,52 +73767,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-iba
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -67060,17 +73954,17 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
+iba
+iba
+iba
 hrZ
 hrZ
 hrZ
@@ -67130,26 +74024,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -67317,6 +74211,8 @@ iba
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -67385,28 +74281,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -67574,8 +74468,8 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -67644,26 +74538,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -67831,8 +74725,8 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -67901,26 +74795,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -68088,6 +74982,8 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -68156,28 +75052,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -68345,6 +75239,8 @@ hrZ
 hrZ
 hrZ
 hrZ
+shC
+shC
 hrZ
 hrZ
 hrZ
@@ -68413,28 +75309,26 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -68602,96 +75496,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC
@@ -68859,96 +75753,96 @@ hrZ
 hrZ
 hrZ
 hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-hrZ
-lKi
-lKi
-hrZ
-hrZ
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
 shC
 shC
 shC

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -682,6 +682,7 @@
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
 	},
+/obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
@@ -33207,10 +33208,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
 "gvL" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 246;
-	destination_y = 75;
-	destination_z = 11
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/tunnel/northeast)
 "gvR" = (
@@ -37463,10 +37463,9 @@
 	},
 /area/f13/building/massfusion)
 "irY" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 248;
-	destination_y = 75;
-	destination_z = 11
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/tunnel/northeast)
 "isj" = (
@@ -41250,8 +41249,7 @@
 /area/f13/caves)
 "jTR" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "jTY" = (
@@ -42245,8 +42243,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "ksK" = (
@@ -44108,13 +44105,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"lew" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 247;
-	destination_y = 75;
-	destination_z = 11
-	},
-/area/f13/tunnel/northeast)
 "leO" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -46803,10 +46793,7 @@
 	},
 /area/f13/building/firestation)
 "mfk" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
-	pixel_x = 32
-	},
+/obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
@@ -52828,13 +52815,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
-"oGu" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 243;
-	destination_y = 75;
-	destination_z = 11
-	},
-/area/f13/tunnel/northeast)
 "oGJ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -71124,10 +71104,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "wiN" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 244;
-	destination_y = 75;
-	destination_z = 11
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/tunnel/northeast)
 "wiQ" = (
@@ -71264,10 +71243,7 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "wkv" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
-	pixel_x = -32
-	},
+/obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
@@ -74147,13 +74123,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
-"xwV" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 245;
-	destination_y = 75;
-	destination_z = 11
-	},
-/area/f13/tunnel/northeast)
 "xxx" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -134856,7 +134825,7 @@ bkR
 (230,1,1) = {"
 aag
 wkv
-hKY
+wiN
 dNW
 dNW
 dNW
@@ -135111,8 +135080,8 @@ xLv
 aaa
 "}
 (231,1,1) = {"
-oGu
-aas
+aag
+gvL
 aas
 aas
 fKM
@@ -135368,8 +135337,8 @@ xLv
 aaa
 "}
 (232,1,1) = {"
-wiN
-aas
+aag
+gvL
 aas
 fKM
 hVG
@@ -135625,8 +135594,8 @@ xLv
 aaa
 "}
 (233,1,1) = {"
-xwV
-aas
+aag
+gvL
 aas
 fKM
 hVG
@@ -135882,7 +135851,7 @@ xLv
 aaa
 "}
 (234,1,1) = {"
-xwV
+aag
 acA
 aaz
 aaz
@@ -136139,8 +136108,8 @@ xLv
 aaa
 "}
 (235,1,1) = {"
+aag
 gvL
-aas
 aas
 aas
 aaS
@@ -136396,8 +136365,8 @@ xLv
 aaa
 "}
 (236,1,1) = {"
-lew
-aas
+aag
+gvL
 aas
 aas
 fKM
@@ -136653,8 +136622,8 @@ juJ
 aaa
 "}
 (237,1,1) = {"
-irY
-aas
+aag
+gvL
 aas
 aas
 aas
@@ -136912,7 +136881,7 @@ aaa
 (238,1,1) = {"
 aag
 mfk
-aao
+irY
 lvB
 lvB
 lvB

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4538,6 +4538,12 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/centcom/evac)
+"pt" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
 "pu" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment Room";
@@ -4699,6 +4705,12 @@
 /obj/effect/landmark/ai_multicam_room,
 /turf/open/ai_visible,
 /area/ai_multicam_room)
+"pY" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/centcom{
@@ -6881,6 +6893,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"xL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "xR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -7630,6 +7648,12 @@
 /obj/effect/landmark/deathmatch,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/centcom/evac)
+"Dg" = (
+/obj/vertibird,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
 "Dh" = (
 /obj/item/clipboard,
 /obj/item/folder/red,
@@ -8262,6 +8286,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/centcom/evac)
+"Jf" = (
+/obj/machinery/light/floor{
+	light_color = "#6C8DA6";
+	bulb_colour = "#6C8DA6"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/centcom/evac)
 "Jg" = (
 /obj/machinery/camera{
@@ -8901,6 +8934,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"NL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "NR" = (
 /obj/machinery/light{
 	dir = 8
@@ -8942,6 +8981,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"Oz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Vertibird Hangar"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "OA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -8967,6 +9016,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"Pg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "Pq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -9595,6 +9650,10 @@
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/centcom/evac)
+"Xc" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/centcom/evac)
 "Xz" = (
 /obj/machinery/light/small,
@@ -40206,7 +40265,7 @@ qx
 qx
 qx
 qx
-qx
+Oz
 qx
 qx
 qx
@@ -40456,19 +40515,19 @@ rb
 rb
 rb
 rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
+qx
+Xc
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+pY
+qx
 rb
 rb
 aa
@@ -40713,19 +40772,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+Jf
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Jf
+Pg
+qx
 aa
 aa
 aa
@@ -40970,19 +41029,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 aa
@@ -41227,19 +41286,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 aa
@@ -41484,19 +41543,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 aa
@@ -41741,19 +41800,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 rb
@@ -41998,19 +42057,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+pt
+CQ
+Dg
+CQ
+CQ
+Pg
+qx
 aa
 aa
 rb
@@ -42255,19 +42314,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 rb
@@ -42512,19 +42571,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 rb
@@ -42769,19 +42828,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 rb
@@ -43026,19 +43085,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Pg
+qx
 aa
 aa
 rb
@@ -43283,19 +43342,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+AW
+Jf
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Jf
+Pg
+qx
 aa
 aa
 aa
@@ -43540,19 +43599,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+xL
+wK
+wK
+wK
+wK
+wK
+wK
+wK
+wK
+wK
+NL
+qx
 aa
 aa
 aa
@@ -43797,19 +43856,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
 aa
 aa
 aa

--- a/_maps/pahrump.json
+++ b/_maps/pahrump.json
@@ -10,24 +10,23 @@
 		"RockSprings.dmm",
 		"RockSprings-Upper.dmm",
 		"Warren.dmm",
-		"Warren-Upper.dmm",
-		"Mountain-Range.dmm"
+		"Warren-Upper.dmm"
 	],
-	"station_ruin_budget":0,
-	"space_ruin_levels":0,
-	"space_empty_levels":0,
+	"station_ruin_budget": 0,
+	"space_ruin_levels": 0,
+	"space_empty_levels": 0,
 	"shuttles": {
-		"cargo":"cargo_pahrump",
+		"cargo": "cargo_pahrump",
 		"emergency": "emergency_pahrump",
 		"ferry": "ferry_fancy"
 	},
-	"traits":[
+	"traits": [
 		{
 			"Gravity": true,
 			"Baseturf": "/turf/open/indestructible/ground/inside/mountain",
 			"Up": 1,
 			"No Parallax": true,
-			"Linkage" : null,
+			"Linkage": null,
 			"Name": "Dungeons"
 		},
 		{
@@ -37,7 +36,7 @@
 			"Up": 1,
 			"Down": 1,
 			"No Parallax": true,
-			"Linkage" : null,
+			"Linkage": null,
 			"Name": "Lower Sheridan"
 		},
 		{
@@ -48,7 +47,7 @@
 			"Up": 1,
 			"Down": 1,
 			"No Parallax": true,
-			"Linkage" : "Cross",
+			"Linkage": "Cross",
 			"Name": "Sheridan"
 		},
 		{
@@ -57,7 +56,7 @@
 			"Up": 1,
 			"Down": 1,
 			"No Parallax": true,
-			"Linkage" : null,
+			"Linkage": null,
 			"Above": true,
 			"Name": "Upper Sheridan"
 		},
@@ -65,7 +64,7 @@
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
 			"Down": 1,
-			"Linkage" : null,
+			"Linkage": null,
 			"No Parallax": true,
 			"Above": true,
 			"Name": "Upper Sheridan 2"
@@ -77,14 +76,14 @@
 			"Surface": true,
 			"Up": 1,
 			"No Parallax": true,
-			"Linkage" : "Cross",
+			"Linkage": "Cross",
 			"Name": "Rock Springs"
 		},
 		{
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
 			"Down": 1,
-			"Linkage" : null,
+			"Linkage": null,
 			"No Parallax": true,
 			"Above": true,
 			"Name": "Upper Rock Springs"
@@ -96,26 +95,17 @@
 			"Surface": true,
 			"Up": 1,
 			"No Parallax": true,
-			"Linkage" : "Cross",
+			"Linkage": "Cross",
 			"Name": "Warren"
 		},
 		{
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
 			"Down": 1,
-			"Linkage" : null,
+			"Linkage": null,
 			"No Parallax": true,
 			"Above": true,
 			"Name": "Upper Warren"
-		},
-		{
-			"Gravity": true,
-			"Baseturf": "/turf/open/indestructible/ground/inside/mountain",
-			"Station": 1,
-			"Surface": true,
-			"No Parallax": true,
-			"Linkage" : null,
-			"Name": "Mountain Range"
 		}
 	],
 	"minetype": "none"

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -1,3 +1,4 @@
+/*
 /datum/job/enclave
 	department_flag = ENCLAVE
 	selection_color = "#434944"
@@ -847,3 +848,4 @@
 	R.apply_pref_name("cyborg", M.client)
 	R.gender = NEUTER
 	R.forceMove(pick(GLOB.enclave_borg_start))
+*/

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -284,7 +284,6 @@ GLOBAL_LIST_INIT(position_categories, list(
 	EXP_TYPE_LEGION = list("jobs" = legion_positions, "color" = "#f81717"),
 	EXP_TYPE_KHAN = list("jobs" = khan_positions, "color" = "#006666"),
 	EXP_TYPE_BROTHERHOOD = list("jobs" = brotherhood_positions, "color" = "#95a5a6"),
-	EXP_TYPE_ENCLAVE = list("jobs" = enclave_positions, "color" = "#434944"),
 ))
 
 GLOBAL_LIST_INIT(exp_jobsmap, list(
@@ -308,7 +307,6 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_WASTELAND = list("titles" = wasteland_positions),
 	EXP_TYPE_KHAN = list("titles" = khan_positions),
 	EXP_TYPE_FOLLOWERS = list("titles" = followers_positions),
-	EXP_TYPE_ENCLAVE = list("titles" = enclave_positions),
 	EXP_TYPE_RANGER = list("titles" = list("NCR Veteran Ranger","NCR Ranger")),
 	EXP_TYPE_SCRIBE = list("titles" = list("Scribe")),
 	EXP_TYPE_DECANUS = list("titles" = list("Legion Decanus")),

--- a/code/modules/mapping/map_config.dm
+++ b/code/modules/mapping/map_config.dm
@@ -18,7 +18,7 @@
 	// Config actually from the JSON - should default to Box
 	var/map_name = "La Verkin, Utah"
 	var/map_path = "map_files/Pahrump-Sunset"
-	var/map_file = list("Dungeons.dmm", "Pahrump-Sunset-Lower.dmm", "Pahrump-Sunset.dmm", "Pahrump-Sunset-Upper.dmm", "Pahrump-Sunset-Upper-2.dmm", "RockSprings.dmm", "RockSprings-Upper.dmm", "Warren.dmm", "Warren-Upper.dmm", "Mountain-Range.dmm")
+	var/map_file = list("Dungeons.dmm", "Pahrump-Sunset-Lower.dmm", "Pahrump-Sunset.dmm", "Pahrump-Sunset-Upper.dmm", "Pahrump-Sunset-Upper-2.dmm", "RockSprings.dmm", "RockSprings-Upper.dmm", "Warren.dmm", "Warren-Upper.dmm")
 	var/list/added_jobs = list()     //Overrides the "none" faction using job name
 	var/list/removed_jobs = list()   //Removes the "none" faction using job name - can also use #all# (case sensitive)
 

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -35,9 +35,6 @@
 		if(istype(previewJob,/datum/job/cyborg))
 			parent.show_character_previews(image('icons/mob/robots.dmi', icon_state = "robot", dir = SOUTH))
 			return
-		if(istype(previewJob,/datum/job/enclave/encborg))
-			parent.show_character_previews(image('icons/mob/robots.dmi', icon_state = "robot", dir = SOUTH))
-			return
 		if(istype(previewJob,/datum/job/followers/f13folborg))
 			parent.show_character_previews(image('icons/mob/robots.dmi', icon_state = "robot", dir = SOUTH))
 			return


### PR DESCRIPTION
## About The Pull Request
https://github.com/f13babylon/f13babylon/pull/590 but modified to be a little better.

- Removes Casper and makes access tunnel into generic spawn matrix area.
- Removes Enclave occupations from preference and latejoin menu so they cannot be selected or seen.
- Adds vertibird to Centcom.
- Adds derelict Enclave base to NML.

## Why It's Good For The Game
Enclave aren't wanted.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog
:cl:
tweak: Removes Enclave and Casper.
/:cl: